### PR TITLE
feat(drives): add drive selector, instance filter, and detailed stats

### DIFF
--- a/frontend/src/pages/DrivesPage.tsx
+++ b/frontend/src/pages/DrivesPage.tsx
@@ -1,18 +1,18 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { api } from '../api/api';
 import type { EstateDriveRow, InstanceDriveRow } from '../api/types';
 import LoadingSpinner from '../components/LoadingSpinner';
 import EmptyState from '../components/EmptyState';
 import CapacityBar from '../components/CapacityBar';
-import { HardDrive, ArrowUpDown, RefreshCw } from 'lucide-react';
+import { HardDrive, ArrowUpDown, RefreshCw, Filter } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { clsx } from 'clsx';
 
 type DriveRow = (EstateDriveRow | InstanceDriveRow) & { InstanceDisplayName?: string | null };
 
-function formatBytes(bytes: number): string {
-  if (!bytes) return 'â€”';
+function formatBytes(bytes: number | null | undefined): string {
+  if (!bytes) return '—';
   if (bytes > 1e12) return `${(bytes / 1e12).toFixed(1)} TB`;
   if (bytes > 1e9) return `${(bytes / 1e9).toFixed(1)} GB`;
   return `${(bytes / 1e6).toFixed(1)} MB`;
@@ -28,6 +28,8 @@ export default function DrivesPage() {
   const [drives, setDrives] = useState<DriveRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [sortDesc, setSortDesc] = useState(true);
+  const [selectedDrive, setSelectedDrive] = useState<string>('');
+  const [selectedInstance, setSelectedInstance] = useState<string>('');
 
   useEffect(() => {
     (async () => {
@@ -42,30 +44,106 @@ export default function DrivesPage() {
     })();
   }, [id]);
 
+  // Unique drive names and instances for filter dropdowns
+  const driveNames = useMemo(() => {
+    const names = new Set(drives.map(d => d.Name).filter(Boolean) as string[]);
+    return [...names].sort();
+  }, [drives]);
+
+  const instanceNames = useMemo(() => {
+    if (id) return []; // already instance-filtered
+    const names = new Set(drives.map(d => d.InstanceDisplayName).filter(Boolean) as string[]);
+    return [...names].sort();
+  }, [drives, id]);
+
+  const filtered = useMemo(() => {
+    return drives.filter(d =>
+      (!selectedDrive || d.Name === selectedDrive) &&
+      (!selectedInstance || d.InstanceDisplayName === selectedInstance)
+    );
+  }, [drives, selectedDrive, selectedInstance]);
+
+  const sorted = useMemo(() =>
+    [...filtered].sort((a, b) =>
+      sortDesc ? getUsedPercent(b) - getUsedPercent(a) : getUsedPercent(a) - getUsedPercent(b)
+    ), [filtered, sortDesc]);
+
   if (loading) return <LoadingSpinner />;
 
-  const sorted = [...drives].sort((a, b) => sortDesc ? getUsedPercent(b) - getUsedPercent(a) : getUsedPercent(a) - getUsedPercent(b));
+  const criticalCount = sorted.filter(d => getUsedPercent(d) >= 85).length;
+  const warnCount = sorted.filter(d => getUsedPercent(d) >= 70 && getUsedPercent(d) < 85).length;
 
   return (
     <div className="space-y-4">
-      <div className="flex items-center justify-between">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
         <div>
-          <div className="flex items-center justify-between">
-            <h1 className="text-2xl font-bold text-white">{id ? 'Instance Drives' : 'Drives'}</h1>
-            <span className="text-xs text-gray-500 flex items-center gap-1">
-              <RefreshCw className="w-3 h-3" /> Auto-refresh 30s
-            </span>
-          </div>
-          <p className="text-sm text-gray-400">{sorted.length} drives{id ? '' : ' across all instances'}</p>
+          <h1 className="text-2xl font-bold text-white">{id ? 'Instance Drives' : 'Drives'}</h1>
+          <p className="text-sm text-gray-400 mt-0.5">
+            {sorted.length} drives{id ? '' : ' across all instances'}
+            {criticalCount > 0 && <span className="ml-2 text-red-400">· {criticalCount} critical (&gt;85%)</span>}
+            {warnCount > 0 && <span className="ml-2 text-yellow-400">· {warnCount} warning (&gt;70%)</span>}
+          </p>
         </div>
-        <button
-          onClick={() => setSortDesc(!sortDesc)}
-          className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-gray-400 hover:text-white hover:bg-slate-800/50 transition-all"
-        >
-          <ArrowUpDown className="w-4 h-4" />
-          {sortDesc ? 'Most used first' : 'Least used first'}
-        </button>
+        <div className="flex items-center gap-2 flex-wrap justify-end">
+          {/* Instance filter (estate view only) */}
+          {!id && instanceNames.length > 0 && (
+            <select
+              value={selectedInstance}
+              onChange={e => setSelectedInstance(e.target.value)}
+              className="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-gray-300 focus:outline-none"
+            >
+              <option value="">All Instances</option>
+              {instanceNames.map(name => (
+                <option key={name} value={name}>{name}</option>
+              ))}
+            </select>
+          )}
+          {/* Drive name filter */}
+          {driveNames.length > 1 && (
+            <select
+              value={selectedDrive}
+              onChange={e => setSelectedDrive(e.target.value)}
+              className="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-gray-300 focus:outline-none"
+            >
+              <option value="">All Drives</option>
+              {driveNames.map(name => (
+                <option key={name} value={name}>{name}</option>
+              ))}
+            </select>
+          )}
+          <button
+            onClick={() => setSortDesc(!sortDesc)}
+            className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-gray-400 hover:text-white hover:bg-slate-800/50 transition-all"
+          >
+            <ArrowUpDown className="w-4 h-4" />
+            {sortDesc ? 'Most used first' : 'Least used first'}
+          </button>
+          <span className="text-xs text-gray-500 flex items-center gap-1">
+            <RefreshCw className="w-3 h-3" /> Auto-refresh 30s
+          </span>
+        </div>
       </div>
+
+      {/* Active filters badge */}
+      {(selectedDrive || selectedInstance) && (
+        <div className="flex items-center gap-2 text-xs text-gray-400">
+          <Filter className="w-3 h-3" />
+          <span>Filtering by:</span>
+          {selectedInstance && (
+            <span className="px-2 py-0.5 rounded-full bg-blue-400/10 text-blue-400">
+              {selectedInstance}
+              <button onClick={() => setSelectedInstance('')} className="ml-1 hover:text-white">×</button>
+            </span>
+          )}
+          {selectedDrive && (
+            <span className="px-2 py-0.5 rounded-full bg-purple-400/10 text-purple-400">
+              {selectedDrive}
+              <button onClick={() => setSelectedDrive('')} className="ml-1 hover:text-white">×</button>
+            </span>
+          )}
+        </div>
+      )}
 
       {sorted.length === 0 ? (
         <EmptyState message="No drive data available" />
@@ -73,26 +151,55 @@ export default function DrivesPage() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {sorted.map((drive, i) => {
             const pct = getUsedPercent(drive);
-            const borderColor = pct >= 85 ? 'border-red-500/20' : pct >= 70 ? 'border-yellow-500/20' : 'border-white/5';
+            const usedBytes = (drive.Capacity || 0) - (drive.FreeSpace || 0);
+            const borderColor = pct >= 85 ? 'border-red-500/30' : pct >= 70 ? 'border-yellow-500/30' : 'border-white/5';
+            const iconColor = pct >= 85 ? 'text-red-400' : pct >= 70 ? 'text-yellow-400' : 'text-blue-400';
             return (
               <motion.div
                 key={drive.DriveID || i}
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
-                transition={{ delay: i * 0.03 }}
-                className={clsx('glass rounded-xl p-6 border', borderColor)}
+                transition={{ delay: i * 0.02 }}
+                className={clsx('glass rounded-xl p-5 border', borderColor)}
               >
-                <div className="flex items-center gap-3 mb-3">
-                  <HardDrive className={clsx('w-5 h-5', pct >= 85 ? 'text-red-400' : pct >= 70 ? 'text-yellow-400' : 'text-blue-400')} />
-                  <div className="min-w-0">
-                    <p className="text-sm font-medium text-white truncate">{drive.Name}</p>
-                    <p className="text-xs text-gray-500">{drive.InstanceDisplayName || 'â€”'}</p>
+                {/* Drive header */}
+                <div className="flex items-start gap-3 mb-4">
+                  <HardDrive className={clsx('w-5 h-5 mt-0.5 shrink-0', iconColor)} />
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="text-sm font-semibold text-white truncate">{drive.Name || '—'}</p>
+                      <span className={clsx('text-xs font-bold shrink-0',
+                        pct >= 85 ? 'text-red-400' : pct >= 70 ? 'text-yellow-400' : 'text-green-400'
+                      )}>{pct.toFixed(1)}%</span>
+                    </div>
+                    {drive.Label && (
+                      <p className="text-xs text-gray-500 truncate">{drive.Label}</p>
+                    )}
+                    {!id && drive.InstanceDisplayName && (
+                      <p className="text-xs text-gray-500 truncate">{drive.InstanceDisplayName}</p>
+                    )}
                   </div>
                 </div>
-                <CapacityBar used={(drive.Capacity || 0) - (drive.FreeSpace || 0)} total={drive.Capacity || 0} />
-                <div className="flex justify-between mt-2 text-xs text-gray-500">
-                  <span>{formatBytes(drive.FreeSpace || 0)} free</span>
-                  <span>{formatBytes(drive.Capacity || 0)} total</span>
+
+                {/* Capacity bar */}
+                <CapacityBar used={usedBytes} total={drive.Capacity || 0} />
+
+                {/* Details grid */}
+                <div className="grid grid-cols-3 gap-2 mt-3 text-xs">
+                  <div className="text-center">
+                    <p className="text-gray-500">Used</p>
+                    <p className="text-white font-medium">{formatBytes(usedBytes)}</p>
+                  </div>
+                  <div className="text-center">
+                    <p className="text-gray-500">Free</p>
+                    <p className={clsx('font-medium', pct >= 85 ? 'text-red-400' : pct >= 70 ? 'text-yellow-400' : 'text-gray-300')}>
+                      {formatBytes(drive.FreeSpace)}
+                    </p>
+                  </div>
+                  <div className="text-center">
+                    <p className="text-gray-500">Total</p>
+                    <p className="text-gray-300 font-medium">{formatBytes(drive.Capacity)}</p>
+                  </div>
                 </div>
               </motion.div>
             );

--- a/frontend/src/pages/SlowQueriesPage.tsx
+++ b/frontend/src/pages/SlowQueriesPage.tsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from 'react';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import { api } from '../api/api';
 import type { InstanceListRow, SlowQueryRow } from '../api/types';
 import LoadingSpinner from '../components/LoadingSpinner';
@@ -13,7 +13,8 @@ export default function SlowQueriesPage() {
   const [instances, setInstances] = useState<InstanceListRow[]>([]);
   const [selectedInstance, setSelectedInstance] = useState<number | undefined>();
   const [hours, setHours] = useState(24);
-  const [expandedRows, setExpandedRows] = useState<Set<number>>(new Set());
+  const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+  const [expandedServers, setExpandedServers] = useState<Set<string>>(new Set());
   const [dbFilter, setDbFilter] = useState('');
   const [appFilter, setAppFilter] = useState('');
 
@@ -29,10 +30,23 @@ export default function SlowQueriesPage() {
       .finally(() => setLoading(false));
   }, [selectedInstance, hours]);
 
-  const toggleRow = (i: number) => {
+  useEffect(() => {
+    setExpandedRows(new Set());
+    setExpandedServers(new Set());
+  }, [selectedInstance, hours, dbFilter, appFilter]);
+
+  const toggleRow = (key: string) => {
     setExpandedRows(prev => {
       const next = new Set(prev);
-      next.has(i) ? next.delete(i) : next.add(i);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  };
+
+  const toggleServer = (serverName: string) => {
+    setExpandedServers(prev => {
+      const next = new Set(prev);
+      next.has(serverName) ? next.delete(serverName) : next.add(serverName);
       return next;
     });
   };
@@ -45,12 +59,68 @@ export default function SlowQueriesPage() {
     (!appFilter || r.client_app_name === appFilter)
   );
 
+  const groupedByInstance = useMemo(() => {
+    return filtered.reduce((acc, row) => {
+      const serverName = row.InstanceDisplayName || String(row.InstanceID);
+      if (!acc[serverName]) {
+        acc[serverName] = [];
+      }
+      acc[serverName].push(row);
+      return acc;
+    }, {} as Record<string, SlowQueryRow[]>);
+  }, [filtered]);
+
+  const serverNames = useMemo(() => Object.keys(groupedByInstance).sort(), [groupedByInstance]);
+
   const fmtMs = (ms: number | null | undefined) => {
     if (ms == null) return '-';
     if (ms < 1000) return `${ms}ms`;
     if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
     return `${(ms / 60000).toFixed(1)}m`;
   };
+
+  const renderRows = (rows: SlowQueryRow[], keyPrefix: string, showInstanceColumn: boolean) => (
+    rows.map((row, i) => {
+      const rowKey = `${keyPrefix}-${row.InstanceID}-${row.DatabaseID ?? 'db'}-${i}`;
+      return (
+        <Fragment key={rowKey}>
+          <tr onClick={() => toggleRow(rowKey)}
+            className="border-b border-white/5 cursor-pointer hover:bg-slate-800/50 transition-colors">
+            <td className="px-4 py-3 text-gray-500">
+              {expandedRows.has(rowKey) ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+            </td>
+            {showInstanceColumn && (
+              <td className="px-4 py-3 text-gray-300">{row.InstanceDisplayName || row.InstanceID}</td>
+            )}
+            <td className="px-4 py-3 text-gray-300">{row.database_name || '-'}</td>
+            <td className="px-4 py-3 text-gray-300 font-mono text-xs">{row.object_name || '-'}</td>
+            <td className="px-4 py-3">
+              <span className={clsx('font-medium',
+                (row.duration_ms || 0) > 30000 ? 'text-red-400' :
+                (row.duration_ms || 0) > 5000 ? 'text-yellow-400' : 'text-gray-300'
+              )}>{fmtMs(row.duration_ms)}</span>
+            </td>
+            <td className="px-4 py-3 text-gray-300">{fmtMs(row.cpu_time_ms)}</td>
+            <td className="px-4 py-3 text-gray-300">{row.logical_reads?.toLocaleString() || '-'}</td>
+            <td className="px-4 py-3 text-gray-300">{row.writes?.toLocaleString() || '-'}</td>
+            <td className="px-4 py-3 text-gray-400 text-xs">{row.client_hostname || '-'}</td>
+            <td className="px-4 py-3 text-gray-400 text-xs">{row.client_app_name || '-'}</td>
+            <td className="px-4 py-3 text-gray-400 text-xs">{row.SnapshotDate ? new Date(row.SnapshotDate).toLocaleString() : '-'}</td>
+          </tr>
+          {expandedRows.has(rowKey) && (
+            <tr className="border-b border-white/5 bg-white/[0.02]">
+              <td colSpan={showInstanceColumn ? 11 : 10} className="px-6 py-4">
+                <div className="text-xs text-gray-500 mb-1">Query Text</div>
+                <pre className="text-xs text-gray-300 whitespace-pre-wrap font-mono bg-black/20 rounded-lg p-3 max-h-48 overflow-y-auto">
+                  {row.query_text || 'N/A'}
+                </pre>
+              </td>
+            </tr>
+          )}
+        </Fragment>
+      );
+    })
+  );
 
   if (loading) return <LoadingSpinner />;
 
@@ -105,7 +175,7 @@ export default function SlowQueriesPage() {
           <Clock className="w-12 h-12 text-gray-600 mx-auto mb-4" />
           <p className="text-gray-400">No slow queries found</p>
         </motion.div>
-      ) : (
+      ) : selectedInstance ? (
         <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} className="glass-ultra rounded-2xl overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -125,45 +195,67 @@ export default function SlowQueriesPage() {
                 </tr>
               </thead>
               <tbody>
-                {filtered.map((row, i) => (
-                  <Fragment key={`${row.InstanceID}-${row.DatabaseID ?? i}-${i}`}>
-                    <tr onClick={() => toggleRow(i)}
-                      className="border-b border-white/5 cursor-pointer hover:bg-slate-800/50 transition-colors">
-                      <td className="px-4 py-3 text-gray-500">
-                        {expandedRows.has(i) ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-                      </td>
-                      <td className="px-4 py-3 text-gray-300">{row.InstanceDisplayName || row.InstanceID}</td>
-                      <td className="px-4 py-3 text-gray-300">{row.database_name || '-'}</td>
-                      <td className="px-4 py-3 text-gray-300 font-mono text-xs">{row.object_name || '-'}</td>
-                      <td className="px-4 py-3">
-                        <span className={clsx('font-medium',
-                          (row.duration_ms || 0) > 30000 ? 'text-red-400' :
-                          (row.duration_ms || 0) > 5000 ? 'text-yellow-400' : 'text-gray-300'
-                        )}>{fmtMs(row.duration_ms)}</span>
-                      </td>
-                      <td className="px-4 py-3 text-gray-300">{fmtMs(row.cpu_time_ms)}</td>
-                      <td className="px-4 py-3 text-gray-300">{row.logical_reads?.toLocaleString() || '-'}</td>
-                      <td className="px-4 py-3 text-gray-300">{row.writes?.toLocaleString() || '-'}</td>
-                      <td className="px-4 py-3 text-gray-400 text-xs">{row.client_hostname || '-'}</td>
-                      <td className="px-4 py-3 text-gray-400 text-xs">{row.client_app_name || '-'}</td>
-                      <td className="px-4 py-3 text-gray-400 text-xs">{row.SnapshotDate ? new Date(row.SnapshotDate).toLocaleString() : '-'}</td>
-                    </tr>
-                    {expandedRows.has(i) && (
-                      <tr className="border-b border-white/5 bg-white/[0.02]">
-                        <td colSpan={11} className="px-6 py-4">
-                          <div className="text-xs text-gray-500 mb-1">Query Text</div>
-                          <pre className="text-xs text-gray-300 whitespace-pre-wrap font-mono bg-black/20 rounded-lg p-3 max-h-48 overflow-y-auto">
-                            {row.query_text || 'N/A'}
-                          </pre>
-                        </td>
-                      </tr>
-                    )}
-                  </Fragment>
-                ))}
+                {renderRows(filtered, 'instance-view', true)}
               </tbody>
             </table>
           </div>
         </motion.div>
+      ) : (
+        <div className="space-y-4">
+          {serverNames.map((serverName) => {
+            const serverRows = groupedByInstance[serverName] || [];
+            const isExpanded = expandedServers.has(serverName);
+
+            return (
+              <motion.div
+                key={serverName}
+                initial={{ opacity: 0, y: 10 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="glass-ultra rounded-2xl overflow-hidden"
+              >
+                <button
+                  type="button"
+                  onClick={() => toggleServer(serverName)}
+                  className="w-full flex items-center justify-between px-4 py-3 border-b border-white/10 hover:bg-slate-800/40 transition-colors"
+                >
+                  <div className="flex items-center gap-2 text-left">
+                    {isExpanded ? (
+                      <ChevronDown className="w-4 h-4 text-gray-400" />
+                    ) : (
+                      <ChevronRight className="w-4 h-4 text-gray-400" />
+                    )}
+                    <span className="text-sm font-semibold text-gray-200">{serverName}</span>
+                  </div>
+                  <span className="text-xs text-gray-400">{serverRows.length} quer{serverRows.length === 1 ? 'y' : 'ies'}</span>
+                </button>
+
+                {isExpanded && (
+                  <div className="overflow-x-auto">
+                    <table className="w-full text-sm">
+                      <thead>
+                        <tr className="border-b border-white/10 text-left">
+                          <th className="px-4 py-3 text-gray-300 font-semibold"></th>
+                          <th className="px-4 py-3 text-gray-300 font-semibold">Database</th>
+                          <th className="px-4 py-3 text-gray-300 font-semibold">Object</th>
+                          <th className="px-4 py-3 text-gray-300 font-semibold">Duration</th>
+                          <th className="px-4 py-3 text-gray-300 font-semibold">CPU</th>
+                          <th className="px-4 py-3 text-gray-300 font-semibold">Reads</th>
+                          <th className="px-4 py-3 text-gray-300 font-semibold">Writes</th>
+                          <th className="px-4 py-3 text-gray-300 font-semibold">Client</th>
+                          <th className="px-4 py-3 text-gray-300 font-semibold">App</th>
+                          <th className="px-4 py-3 text-gray-300 font-semibold">Timestamp</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {renderRows(serverRows, `server-${serverName}`, false)}
+                      </tbody>
+                    </table>
+                  </div>
+                )}
+              </motion.div>
+            );
+          })}
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
## Changes

Improves the Drives page based on feedback from @edwillis777 (#28):

- **Drive selector** — filter by specific drive name/letter
- **Instance filter** — filter by server in estate view
- **Active filter badges** with one-click clear
- **Usage stats** — Used / Free / Total shown as three columns per card
- **Percentage** displayed on each card with color coding
- **Drive label** shown when available
- **Critical/Warning counts** in the page header

Note: read/write latency requires backend changes (the API currently doesn't expose those fields). Tracked separately in #31.

Partially addresses #31