### PR TITLE
fix(ui): fix TabNav appearance in light theme

### DIFF
--- a/frontend/src/components/TabNav.tsx
+++ b/frontend/src/components/TabNav.tsx
@@ -8,7 +8,7 @@ interface Tab {
 
 export default function TabNav({ tabs, active, onChange }: { tabs: Tab[]; active: string; onChange: (key: string) => void }) {
   return (
-    <div className="flex gap-1 p-1 bg-white/5 rounded-lg w-fit">
+    <div className="tabnav-container flex gap-1 p-1 rounded-lg w-fit">
       {tabs.map(tab => (
         <button
           key={tab.key}
@@ -17,7 +17,7 @@ export default function TabNav({ tabs, active, onChange }: { tabs: Tab[]; active
             'px-4 py-2 text-sm font-medium rounded-md transition-all',
             active === tab.key
               ? 'bg-blue-500/20 text-blue-400 shadow-sm'
-              : 'text-gray-400 hover:text-gray-200 hover:bg-slate-800/50'
+              : 'tabnav-inactive text-gray-400 hover:text-gray-200'
           )}
         >
           {tab.label}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -104,3 +104,25 @@ body {
   background: rgba(255, 255, 255, 0.9);
   border-color: rgba(0, 0, 0, 0.1);
 }
+
+/* TabNav — dark default, light-mode override */
+.tabnav-container {
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.tabnav-inactive:hover {
+  background: rgba(51, 65, 85, 0.5);
+}
+
+.light-mode .tabnav-container {
+  background: rgba(148, 163, 184, 0.25);
+}
+
+.light-mode .tabnav-inactive {
+  color: #475569;
+}
+
+.light-mode .tabnav-inactive:hover {
+  background: rgba(148, 163, 184, 0.35);
+  color: #1e293b;
+}


### PR DESCRIPTION
## Problem

Dashboard tabs appeared dark even when the light theme was selected (#41).

The TabNav component used `bg-white/5` (5% white opacity) which renders as a dark semi-transparent overlay in light mode.

## Fix

Replaced with theme-aware CSS classes via `.tabnav-container`:
- **Dark mode**: keeps the original subtle dark background
- **Light mode**: uses a visible slate background with readable text colors

Closes #41