### PR TITLE
feat(running-queries): show session details on SPID expand

### DIFF
--- a/backend/Endpoints/PerformanceEndpointMappings.cs
+++ b/backend/Endpoints/PerformanceEndpointMappings.cs
@@ -56,6 +56,9 @@ public static class PerformanceEndpointMappings
                            rq.SnapshotDateUTC AS SnapshotDate,
                            rq.database_id,
                            d.name AS database_name,
+                           rq.login_name,
+                           rq.host_name,
+                           rq.program_name,
                            CAST(NULL AS nvarchar(max)) AS query_text
                     FROM dbo.RunningQueries rq
                     JOIN dbo.Instances i ON rq.InstanceID = i.InstanceID

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -572,6 +572,9 @@ export interface RunningQueryRow extends ApiRow {
   SnapshotDate?: string | null;
   database_id?: number | null;
   database_name?: string | null;
+  login_name?: string | null;
+  host_name?: string | null;
+  program_name?: string | null;
   query_text?: string | null;
 }
 

--- a/frontend/src/pages/RunningQueriesPage.tsx
+++ b/frontend/src/pages/RunningQueriesPage.tsx
@@ -147,6 +147,23 @@ export default function RunningQueriesPage() {
                       {expandedRows.has(i) && (
                         <tr className="border-b border-white/5 bg-white/[0.02]">
                           <td colSpan={12} className="px-6 py-4">
+                            <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-3 text-xs">
+                              {row.login_name && (
+                                <div><span className="text-gray-500">Login: </span><span className="text-gray-300">{row.login_name}</span></div>
+                              )}
+                              {row.host_name && (
+                                <div><span className="text-gray-500">Host: </span><span className="text-gray-300">{row.host_name}</span></div>
+                              )}
+                              {row.program_name && (
+                                <div className="col-span-2"><span className="text-gray-500">Program: </span><span className="text-gray-300">{row.program_name}</span></div>
+                              )}
+                              {row.wait_resource && (
+                                <div className="col-span-2"><span className="text-gray-500">Wait resource: </span><span className="text-gray-300 font-mono">{row.wait_resource}</span></div>
+                              )}
+                              {row.logical_reads != null && (
+                                <div><span className="text-gray-500">Logical reads: </span><span className="text-gray-300">{row.logical_reads.toLocaleString()}</span></div>
+                              )}
+                            </div>
                             <div className="text-xs text-gray-500 mb-1">Query Text</div>
                             <pre className="text-xs text-gray-300 whitespace-pre-wrap font-mono bg-black/20 rounded-lg p-3 max-h-48 overflow-y-auto">
                               {row.query_text || 'N/A'}


### PR DESCRIPTION
When clicking on a session row in Running Queries, the expanded panel now shows: login name, host name, program name, wait resource, logical reads.\n\nAlso adds these fields to the backend query and TypeScript types.\n\nPartial fix for #38