### PR TITLE
feat: add navigation menu for all pages (#50)

### DIFF
--- a/frontend/src/components/InstanceTree.tsx
+++ b/frontend/src/components/InstanceTree.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState, useMemo } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 import {
-  Database, ChevronRight, ChevronDown, LayoutDashboard, Bell, HardDrive, Network,
+  Database, ChevronRight, ChevronDown, HardDrive,
   Settings, ClipboardCheck, Shield, Play, BarChart3, Search, LogOut, User, Folder, Server,
-  FileSpreadsheet, TrendingDown, Activity, Monitor
 } from 'lucide-react';
 import { api } from '../api/api';
 import { getAuthSession } from '../auth/session';
+import NavMenu from './NavMenu';
 import type { TreeInstanceNode } from '../api/types';
 
 const versionMap: Record<number, string> = {
@@ -14,15 +14,6 @@ const versionMap: Record<number, string> = {
   14: 'SQL Server 2017', 13: 'SQL Server 2016', 12: 'SQL Server 2014',
   11: 'SQL Server 2012', 10: 'SQL Server 2008',
 };
-
-const globalViews = [
-  { path: '/', icon: LayoutDashboard, label: 'Dashboard' },
-  { path: '/monitor', icon: Monitor, label: 'SQL Monitor' },
-  { path: '/alerts', icon: Bell, label: 'Alerts' },
-  { path: '/estate/backups', icon: Database, label: 'Backups' },
-  { path: '/drives', icon: HardDrive, label: 'Drives' },
-  { path: '/availability-groups', icon: Network, label: 'AlwaysOn Overview' },
-];
 
 const instanceCategories = [
   { key: 'configuration', icon: Settings, label: 'Configuration', path: (id: number) => `/instances/${id}/configuration` },
@@ -131,42 +122,7 @@ export default function InstanceTree({ onLogout }: { onLogout: () => void }) {
       </div>
 
       <div className="flex-1 overflow-y-auto" style={{ scrollbarWidth: 'thin', scrollbarColor: '#475569 transparent' }}>
-        {/* Global Views */}
-        <div className="px-3 py-2">
-          <div className="text-xs font-semibold uppercase tracking-wider text-gray-500 px-0 py-2">Global Views</div>
-          {globalViews.map(item => (
-            <Link key={item.path} to={item.path}
-              className={`flex items-center gap-2.5 py-1.5 px-2 rounded text-sm transition-all ${
-                isActive(item.path)
-                  ? 'bg-blue-500/15 text-blue-400 border-l-2 border-blue-400'
-                  : 'text-gray-400 hover:text-white hover:bg-white/5 border-l-2 border-transparent'
-              }`}>
-              <item.icon className={`w-4 h-4 ${isActive(item.path) ? 'text-blue-400' : 'text-gray-500'}`} />
-              <span>{item.label}</span>
-            </Link>
-          ))}
-        </div>
-
-        {/* Reporting */}
-        <div className="px-3 py-2">
-          <div className="text-xs font-semibold uppercase tracking-wider text-gray-500 px-0 py-2">Reporting</div>
-          {[
-            { path: '/reports/licenses', icon: FileSpreadsheet, label: 'License Overview' },
-            { path: '/reports/underutilized', icon: TrendingDown, label: 'Underutilized Servers' },
-            { path: '/reports/fleet-stats', icon: Activity, label: 'Fleet Statistics' },
-            { path: '/reports/backup-ampel', icon: Shield, label: 'Backup Ampel Report' },
-          ].map(item => (
-            <Link key={item.path} to={item.path}
-              className={`flex items-center gap-2.5 py-1.5 px-2 rounded text-sm transition-all ${
-                isActive(item.path)
-                  ? 'bg-blue-500/15 text-blue-400 border-l-2 border-blue-400'
-                  : 'text-gray-400 hover:text-white hover:bg-white/5 border-l-2 border-transparent'
-              }`}>
-              <item.icon className={`w-4 h-4 ${isActive(item.path) ? 'text-blue-400' : 'text-gray-500'}`} />
-              <span>{item.label}</span>
-            </Link>
-          ))}
-        </div>
+        <NavMenu />
 
         {/* SQL Servers grouped by version */}
         <div className="px-3 py-2">

--- a/frontend/src/components/NavMenu.tsx
+++ b/frontend/src/components/NavMenu.tsx
@@ -1,0 +1,243 @@
+import { useEffect, useMemo, useState, type ComponentType } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import {
+  Activity,
+  BarChart3,
+  Bell,
+  Blocks,
+  ChevronDown,
+  ChevronRight,
+  Database,
+  Gauge,
+  HardDrive,
+  LayoutDashboard,
+  LineChart,
+  Monitor,
+  Package,
+  Play,
+  Settings,
+  Shield,
+  Wrench,
+  Info,
+} from 'lucide-react';
+import { hasRole } from '../auth/session';
+
+type NavItem = {
+  label: string;
+  path: string;
+  icon: ComponentType<{ className?: string }>;
+};
+
+type NavGroup = {
+  key: string;
+  label: string;
+  icon: ComponentType<{ className?: string }>;
+  adminOnly?: boolean;
+  items: NavItem[];
+};
+
+const STORAGE_KEY = 'sidebar-navmenu-expanded';
+
+const navGroups: NavGroup[] = [
+  {
+    key: 'overview',
+    label: 'Overview',
+    icon: LayoutDashboard,
+    items: [
+      { label: 'Dashboard', path: '/', icon: LayoutDashboard },
+      { label: 'SQL Monitor', path: '/monitor', icon: Monitor },
+      { label: 'Alerts', path: '/alerts', icon: Bell },
+    ],
+  },
+  {
+    key: 'performance',
+    label: 'Performance',
+    icon: Gauge,
+    items: [
+      { label: 'Running Queries', path: '/performance/running-queries', icon: Play },
+      { label: 'Blocking', path: '/performance/blocking', icon: Shield },
+      { label: 'Slow Queries', path: '/performance/slow-queries', icon: LineChart },
+      { label: 'Memory', path: '/performance/memory', icon: Activity },
+      { label: 'I/O Performance', path: '/performance/io', icon: HardDrive },
+      { label: 'Exec Stats', path: '/performance/exec-stats', icon: BarChart3 },
+      { label: 'Waits Timeline', path: '/performance/waits-timeline', icon: Activity },
+      { label: 'Perf Counters', path: '/performance/counters', icon: Gauge },
+      { label: 'Query Store', path: '/performance/query-store', icon: Database },
+    ],
+  },
+  {
+    key: 'monitoring',
+    label: 'Monitoring',
+    icon: Activity,
+    items: [
+      { label: 'Job Timeline', path: '/monitoring/job-timeline', icon: Play },
+      { label: 'Configuration', path: '/monitoring/configuration', icon: Settings },
+      { label: 'Patching', path: '/monitoring/patching', icon: Wrench },
+      { label: 'Schema Changes', path: '/monitoring/schema-changes', icon: Blocks },
+      { label: 'Identity Columns', path: '/monitoring/identity-columns', icon: Database },
+      { label: 'TempDB', path: '/monitoring/tempdb', icon: Database },
+      { label: 'DB Space', path: '/monitoring/db-space', icon: HardDrive },
+    ],
+  },
+  {
+    key: 'storage',
+    label: 'Storage',
+    icon: HardDrive,
+    items: [
+      { label: 'Drives', path: '/drives', icon: HardDrive },
+      { label: 'Estate Disks', path: '/estate/disks', icon: HardDrive },
+      { label: 'Estate Backups', path: '/estate/backups', icon: Database },
+    ],
+  },
+  {
+    key: 'jobs-backups',
+    label: 'Jobs & Backups',
+    icon: Package,
+    items: [
+      { label: 'Jobs', path: '/jobs', icon: Play },
+      { label: 'Backups', path: '/backups', icon: Database },
+      { label: 'Backup Status', path: '/reports/backup-ampel', icon: Shield },
+    ],
+  },
+  {
+    key: 'availability',
+    label: 'Availability',
+    icon: Shield,
+    items: [
+      { label: 'AlwaysOn Overview', path: '/availability-groups', icon: Shield },
+      { label: 'Estate AGs', path: '/estate/availability-groups', icon: Database },
+    ],
+  },
+  {
+    key: 'reports',
+    label: 'Reports',
+    icon: BarChart3,
+    items: [
+      { label: 'Analysis', path: '/analysis', icon: BarChart3 },
+      { label: 'Queries', path: '/queries', icon: LineChart },
+      { label: 'Reports', path: '/reports', icon: BarChart3 },
+      { label: 'Licenses', path: '/reports/licenses', icon: Database },
+      { label: 'Underutilized', path: '/reports/underutilized', icon: Activity },
+      { label: 'Fleet Stats', path: '/reports/fleet-stats', icon: Gauge },
+    ],
+  },
+  {
+    key: 'settings',
+    label: 'Settings',
+    icon: Settings,
+    adminOnly: true,
+    items: [
+      { label: 'Alert Settings', path: '/settings/alerts', icon: Bell },
+      { label: 'Servers', path: '/settings/servers', icon: Database },
+      { label: 'Groups', path: '/settings/groups', icon: Blocks },
+      { label: 'Users', path: '/settings/users', icon: Shield },
+      { label: 'Retention', path: '/settings/retention', icon: Package },
+      { label: 'Thresholds', path: '/settings/thresholds', icon: Gauge },
+    ],
+  },
+  {
+    key: 'about',
+    label: 'About',
+    icon: Info,
+    items: [{ label: 'About', path: '/about', icon: Info }],
+  },
+];
+
+function isPathActive(currentPath: string, targetPath: string) {
+  if (targetPath === '/') return currentPath === '/';
+  return currentPath === targetPath || currentPath.startsWith(`${targetPath}/`);
+}
+
+export default function NavMenu() {
+  const location = useLocation();
+  const isAdmin = hasRole(['Admin']);
+
+  const visibleGroups = useMemo(
+    () => navGroups.filter((group) => !group.adminOnly || isAdmin),
+    [isAdmin]
+  );
+
+  const [expandedGroups, setExpandedGroups] = useState<Record<string, boolean>>(() => {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) return JSON.parse(raw) as Record<string, boolean>;
+    } catch {
+      // ignore localStorage parse problems
+    }
+
+    return Object.fromEntries(visibleGroups.map((group) => [group.key, group.key === 'overview']));
+  });
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(expandedGroups));
+  }, [expandedGroups]);
+
+  useEffect(() => {
+    const activeGroup = visibleGroups.find((group) =>
+      group.items.some((item) => isPathActive(location.pathname, item.path))
+    );
+
+    if (activeGroup && !expandedGroups[activeGroup.key]) {
+      setExpandedGroups((prev) => ({ ...prev, [activeGroup.key]: true }));
+    }
+  }, [location.pathname, visibleGroups, expandedGroups]);
+
+  const toggleGroup = (key: string) => {
+    setExpandedGroups((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  return (
+    <div className="px-3 py-2 border-b border-white/10">
+      <div className="text-xs font-semibold uppercase tracking-wider text-gray-500 px-0 py-2">Navigation</div>
+      <div className="space-y-1">
+        {visibleGroups.map((group) => {
+          const expanded = expandedGroups[group.key] ?? false;
+          const groupHasActiveItem = group.items.some((item) => isPathActive(location.pathname, item.path));
+
+          return (
+            <div key={group.key} className="rounded-md bg-slate-900/40">
+              <button
+                onClick={() => toggleGroup(group.key)}
+                className={`flex items-center gap-2 w-full py-1.5 px-2 rounded text-left text-sm transition-colors ${
+                  groupHasActiveItem
+                    ? 'text-blue-300 bg-blue-500/10'
+                    : 'text-gray-300 hover:text-white hover:bg-white/5'
+                }`}
+              >
+                {expanded ? (
+                  <ChevronDown className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+                ) : (
+                  <ChevronRight className="w-3.5 h-3.5 text-gray-400 shrink-0" />
+                )}
+                <group.icon className={`w-3.5 h-3.5 ${groupHasActiveItem ? 'text-blue-400' : 'text-gray-500'}`} />
+                <span className="font-medium">{group.label}</span>
+              </button>
+
+              {expanded && (
+                <div className="pl-6 pr-1 pb-1">
+                  {group.items.map((item) => {
+                    const active = isPathActive(location.pathname, item.path);
+                    return (
+                      <Link
+                        key={item.path}
+                        to={item.path}
+                        className={`flex items-center gap-2 py-1 px-2 rounded text-sm transition-all border-l-2 ${
+                          active
+                            ? 'bg-blue-500/15 text-blue-400 border-blue-400'
+                            : 'text-gray-400 hover:text-white hover:bg-white/5 border-transparent'
+                        }`}
+                      >
+                        <item.icon className={`w-3.5 h-3.5 ${active ? 'text-blue-400' : 'text-gray-500'}`} />
+                        <span>{item.label}</span>
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new grouped `NavMenu` component with collapsible sections for all application pages
- persist expanded/collapsed group state in localStorage
- highlight active routes and auto-expand the group containing the active page
- hide Settings group for non-admin users via `hasRole(['Admin'])`
- integrate the new Navigation section into `InstanceTree` above the instance tree

Closes #50