### PR TITLE
feat: object filter on Exec Stats + custom datetime range picker (#57 #58)

### DIFF
--- a/backend/Endpoints/PerformanceEndpointMappings.cs
+++ b/backend/Endpoints/PerformanceEndpointMappings.cs
@@ -413,27 +413,41 @@ public static class PerformanceEndpointMappings
 
         endpoints.MapGet("/api/performance/query-store", async (int instanceId, SqlDataService sql, CancellationToken cancellationToken) =>
         {
-            var tables = new[] { "QueryStoreStats", "TopQueries" };
-            foreach (var table in tables)
+            // DBADash stores procedure/object-level execution stats in dbo.ObjectExecutionStats.
+            // There are no separate QueryStoreStats or TopQueries tables in the DBADash schema.
+            // We query ObjectExecutionStats grouped by object to surface the top CPU consumers,
+            // which is the closest equivalent to a Query Store top-queries view. (#55)
+            string note = string.Empty;
+            object data = Array.Empty<object>();
+            try
             {
-                try
-                {
-                    await using var connection = await sql.OpenConnectionAsync(cancellationToken);
-                    await using var command = new SqlCommand($"SELECT TOP 100 * FROM dbo.{table} WHERE InstanceID = @id ORDER BY 1 DESC", connection)
-                    {
-                        CommandTimeout = 60
-                    };
-                    command.Parameters.AddWithValue("@id", instanceId);
-
-                    var data = await EndpointResultMapper.ReadRowsAsync(command, cancellationToken, camelCase: true);
-                    return Results.Ok(new { data, note = string.Empty });
-                }
-                catch
-                {
-                }
+                const string query = """
+                    SELECT TOP 100
+                        os.InstanceID,
+                        COALESCE(i.InstanceDisplayName, i.Instance) AS instanceDisplayName,
+                        obj.ObjectName AS objectName,
+                        obj.SchemaName AS schemaName,
+                        SUM(os.execution_count)                          AS countExecutions,
+                        AVG(CAST(os.total_worker_time   AS FLOAT) / NULLIF(os.execution_count, 0) / 1000.0) AS avgCpuTime,
+                        AVG(CAST(os.total_elapsed_time  AS FLOAT) / NULLIF(os.execution_count, 0) / 1000.0) AS avgDuration,
+                        AVG(CAST(os.total_logical_reads AS FLOAT) / NULLIF(os.execution_count, 0))          AS avgLogicalIoReads,
+                        MAX(os.SnapshotDate) AS lastSeen
+                    FROM dbo.ObjectExecutionStats os
+                    JOIN dbo.Instances  i   ON os.InstanceID = i.InstanceID
+                    JOIN dbo.DBObjects  obj ON os.ObjectID   = obj.ObjectID
+                    WHERE os.InstanceID = @instanceId
+                      AND os.SnapshotDate > DATEADD(hour, -24, GETUTCDATE())
+                    GROUP BY os.InstanceID, i.InstanceDisplayName, i.Instance, obj.ObjectName, obj.SchemaName
+                    ORDER BY SUM(os.total_worker_time) DESC
+                    """;
+                data = await sql.QueryAsync(query, cancellationToken, ("@instanceId", instanceId));
+            }
+            catch (Exception ex)
+            {
+                note = $"Query Store data unavailable: {ex.Message}";
             }
 
-            return Results.Ok(new { data = Array.Empty<object>(), note = "Query Store tables not found" });
+            return Results.Ok(new { data, note });
         }).RequireAuthorization();
 
         return endpoints;

--- a/backend/Endpoints/PerformanceEndpointMappings.cs
+++ b/backend/Endpoints/PerformanceEndpointMappings.cs
@@ -119,12 +119,15 @@ public static class PerformanceEndpointMappings
             }
         }).RequireAuthorization();
 
-        endpoints.MapGet("/api/performance/slow-queries", async (int? instanceId, int? hours, SqlDataService sql, ILogger<Program> logger, CancellationToken cancellationToken) =>
+        endpoints.MapGet("/api/performance/slow-queries", async (int? instanceId, int? hours, DateTimeOffset? from, DateTimeOffset? to, SqlDataService sql, ILogger<Program> logger, CancellationToken cancellationToken) =>
         {
             var effectiveHours = hours ?? 24;
             try
             {
                 var filter = instanceId.HasValue ? "AND sq.InstanceID = @instanceId" : string.Empty;
+                var timeFilter = from.HasValue && to.HasValue
+                    ? "sq.timestamp BETWEEN @from AND @to"
+                    : "sq.timestamp > DATEADD(hour, -@hours, GETUTCDATE())";
                 var query = $"""
                     SELECT TOP 200 sq.InstanceID,
                            COALESCE(i.InstanceDisplayName, i.Instance) AS InstanceDisplayName,
@@ -144,14 +147,16 @@ public static class PerformanceEndpointMappings
                     FROM dbo.SlowQueries sq
                     JOIN dbo.Instances i ON sq.InstanceID = i.InstanceID
                     LEFT JOIN dbo.Databases d ON sq.DatabaseID = d.DatabaseID
-                    WHERE sq.timestamp > DATEADD(hour, -@hours, GETUTCDATE()) {filter}
+                    WHERE {timeFilter} {filter}
                     ORDER BY sq.duration DESC
                     """;
                 var data = await sql.QueryAsync(
                     query,
                     cancellationToken,
                     ("@instanceId", instanceId.HasValue ? instanceId.Value : DBNull.Value),
-                    ("@hours", effectiveHours));
+                    ("@hours", effectiveHours),
+                    ("@from", from.HasValue ? from.Value : DBNull.Value),
+                    ("@to", to.HasValue ? to.Value : DBNull.Value));
                 return Results.Ok(new { data, note = string.Empty });
             }
             catch (Exception ex)
@@ -292,7 +297,7 @@ public static class PerformanceEndpointMappings
             return Results.Ok(new { fileStats, drivePerf, fileNote, driveNote });
         }).RequireAuthorization();
 
-        endpoints.MapGet("/api/performance/exec-stats", async (int? instanceId, int? hours, SqlDataService sql, CancellationToken cancellationToken) =>
+        endpoints.MapGet("/api/performance/exec-stats", async (int? instanceId, int? hours, DateTimeOffset? from, DateTimeOffset? to, SqlDataService sql, CancellationToken cancellationToken) =>
         {
             var effectiveHours = hours ?? 24;
             object data = Array.Empty<object>();
@@ -301,6 +306,9 @@ public static class PerformanceEndpointMappings
             try
             {
                 var filter = instanceId.HasValue ? "AND os.InstanceID = @instanceId" : string.Empty;
+                var timeFilter = from.HasValue && to.HasValue
+                    ? "os.SnapshotDate BETWEEN @from AND @to"
+                    : "os.SnapshotDate > DATEADD(hour, -@hours, GETUTCDATE())";
                 var query = $"""
                     SELECT TOP 500 os.InstanceID,
                            COALESCE(i.InstanceDisplayName, i.Instance) AS InstanceDisplayName,
@@ -316,13 +324,15 @@ public static class PerformanceEndpointMappings
                     FROM dbo.ObjectExecutionStats os
                     JOIN dbo.Instances i ON os.InstanceID = i.InstanceID
                     JOIN dbo.DBObjects dbo_obj ON os.ObjectID = dbo_obj.ObjectID
-                    WHERE os.SnapshotDate > DATEADD(hour, -@hours, GETUTCDATE()) {filter}
+                    WHERE {timeFilter} {filter}
                     ORDER BY os.total_worker_time DESC
                     """;
                 data = await sql.QueryAsync(
                     query,
                     cancellationToken,
                     ("@hours", effectiveHours),
+                    ("@from", from.HasValue ? from.Value : DBNull.Value),
+                    ("@to", to.HasValue ? to.Value : DBNull.Value),
                     ("@instanceId", instanceId.HasValue ? instanceId.Value : DBNull.Value));
             }
             catch (Exception ex)
@@ -333,7 +343,7 @@ public static class PerformanceEndpointMappings
             return Results.Ok(new { data, note });
         }).RequireAuthorization();
 
-        endpoints.MapGet("/api/performance/waits-timeline", async (int? instanceId, int? hours, SqlDataService sql, CancellationToken cancellationToken) =>
+        endpoints.MapGet("/api/performance/waits-timeline", async (int? instanceId, int? hours, DateTimeOffset? from, DateTimeOffset? to, SqlDataService sql, CancellationToken cancellationToken) =>
         {
             var effectiveHours = hours ?? 24;
             object data = Array.Empty<object>();
@@ -346,7 +356,10 @@ public static class PerformanceEndpointMappings
 
             try
             {
-                data = await sql.QueryAsync("""
+                var timeFilter = from.HasValue && to.HasValue
+                    ? "w.SnapshotDate BETWEEN @from AND @to"
+                    : "w.SnapshotDate > DATEADD(hour, -@hours, GETUTCDATE())";
+                var query = $"""
                     SELECT w.InstanceID,
                            w.SnapshotDate,
                            wt.WaitType,
@@ -356,12 +369,16 @@ public static class PerformanceEndpointMappings
                     FROM dbo.Waits w
                     JOIN dbo.WaitType wt ON w.WaitTypeID = wt.WaitTypeID
                     WHERE w.InstanceID = @instanceId
-                      AND w.SnapshotDate > DATEADD(hour, -@hours, GETUTCDATE())
+                      AND {timeFilter}
                     ORDER BY w.SnapshotDate
-                    """,
+                    """;
+                data = await sql.QueryAsync(
+                    query,
                     cancellationToken,
                     ("@instanceId", instanceId.Value),
-                    ("@hours", effectiveHours));
+                    ("@hours", effectiveHours),
+                    ("@from", from.HasValue ? from.Value : DBNull.Value),
+                    ("@to", to.HasValue ? to.Value : DBNull.Value));
             }
             catch (Exception ex)
             {
@@ -371,7 +388,7 @@ public static class PerformanceEndpointMappings
             return Results.Ok(new { data, note });
         }).RequireAuthorization();
 
-        endpoints.MapGet("/api/performance/counters", async (int? instanceId, int? hours, SqlDataService sql, CancellationToken cancellationToken) =>
+        endpoints.MapGet("/api/performance/counters", async (int? instanceId, int? hours, DateTimeOffset? from, DateTimeOffset? to, SqlDataService sql, CancellationToken cancellationToken) =>
         {
             var effectiveHours = hours ?? 24;
             object data = Array.Empty<object>();
@@ -384,7 +401,10 @@ public static class PerformanceEndpointMappings
 
             try
             {
-                data = await sql.QueryAsync("""
+                var timeFilter = from.HasValue && to.HasValue
+                    ? "pc.SnapshotDate BETWEEN @from AND @to"
+                    : "pc.SnapshotDate > DATEADD(hour, -@hours, GETUTCDATE())";
+                var query = $"""
                     SELECT pc.InstanceID,
                            COALESCE(i.InstanceDisplayName, i.Instance) AS InstanceDisplayName,
                            c.object_name,
@@ -396,12 +416,16 @@ public static class PerformanceEndpointMappings
                     JOIN dbo.Instances i ON pc.InstanceID = i.InstanceID
                     JOIN dbo.Counters c ON pc.CounterID = c.CounterID
                     WHERE pc.InstanceID = @instanceId
-                      AND pc.SnapshotDate > DATEADD(hour, -@hours, GETUTCDATE())
+                      AND {timeFilter}
                     ORDER BY pc.SnapshotDate
-                    """,
+                    """;
+                data = await sql.QueryAsync(
+                    query,
                     cancellationToken,
                     ("@instanceId", instanceId.Value),
-                    ("@hours", effectiveHours));
+                    ("@hours", effectiveHours),
+                    ("@from", from.HasValue ? from.Value : DBNull.Value),
+                    ("@to", to.HasValue ? to.Value : DBNull.Value));
             }
             catch (Exception ex)
             {

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -148,18 +148,34 @@ export const api = {
     request<ApiDataResponse<RunningQueryRow>>(`/api/performance/running-queries${instanceId ? `?instanceId=${instanceId}` : ''}`),
   performanceBlocking: (instanceId?: number) =>
     request<ApiDataResponse<RunningQueryRow>>(`/api/performance/blocking${instanceId ? `?instanceId=${instanceId}` : ''}`),
-  performanceSlowQueries: (instanceId?: number, hours = 24) =>
-    request<ApiDataResponse<SlowQueryRow>>(`/api/performance/slow-queries?hours=${hours}${instanceId ? `&instanceId=${instanceId}` : ''}`),
+  performanceSlowQueries: (instanceId?: number, hours = 24, from?: string, to?: string) =>
+    request<ApiDataResponse<SlowQueryRow>>(
+      `/api/performance/slow-queries?${from && to
+        ? `from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`
+        : `hours=${hours}`}${instanceId ? `&instanceId=${instanceId}` : ''}`
+    ),
   performanceMemory: (instanceId?: number, hours = 24) =>
     request<MemoryResponse>(`/api/performance/memory?hours=${hours}${instanceId ? `&instanceId=${instanceId}` : ''}`),
   performanceIO: (instanceId?: number, hours = 24) =>
     request<PerformanceIOResponse>(`/api/performance/io?hours=${hours}${instanceId ? `&instanceId=${instanceId}` : ''}`),
-  performanceExecStats: (instanceId?: number, hours = 24) =>
-    request<ApiDataResponse<ExecStatsRow>>(`/api/performance/exec-stats?hours=${hours}${instanceId ? `&instanceId=${instanceId}` : ''}`),
-  performanceWaitsTimeline: (instanceId: number, hours = 24) =>
-    request<ApiDataResponse<WaitTimelineRow>>(`/api/performance/waits-timeline?instanceId=${instanceId}&hours=${hours}`),
-  performanceCounters: (instanceId: number, hours = 24) =>
-    request<ApiDataResponse<PerformanceCounterRow>>(`/api/performance/counters?instanceId=${instanceId}&hours=${hours}`),
+  performanceExecStats: (instanceId?: number, hours = 24, from?: string, to?: string) =>
+    request<ApiDataResponse<ExecStatsRow>>(
+      `/api/performance/exec-stats?${from && to
+        ? `from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`
+        : `hours=${hours}`}${instanceId ? `&instanceId=${instanceId}` : ''}`
+    ),
+  performanceWaitsTimeline: (instanceId: number, hours = 24, from?: string, to?: string) =>
+    request<ApiDataResponse<WaitTimelineRow>>(
+      `/api/performance/waits-timeline?instanceId=${instanceId}&${from && to
+        ? `from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`
+        : `hours=${hours}`}`
+    ),
+  performanceCounters: (instanceId: number, hours = 24, from?: string, to?: string) =>
+    request<ApiDataResponse<PerformanceCounterRow>>(
+      `/api/performance/counters?instanceId=${instanceId}&${from && to
+        ? `from=${encodeURIComponent(from)}&to=${encodeURIComponent(to)}`
+        : `hours=${hours}`}`
+    ),
   monitoringJobTimeline: (instanceId: number, hours = 24) =>
     request<ApiDataResponse<JobTimelineRow>>(`/api/monitoring/job-timeline?instanceId=${instanceId}&hours=${hours}`),
   monitoringConfiguration: (instanceId: number) =>

--- a/frontend/src/components/TimeRangePicker.tsx
+++ b/frontend/src/components/TimeRangePicker.tsx
@@ -3,26 +3,69 @@ import { useSearchParams } from 'react-router-dom';
 import { Clock, ChevronDown } from 'lucide-react';
 import { clsx } from 'clsx';
 
+const CUSTOM_VALUE = 'custom';
+
 const presets = [
   { label: 'Last 1h', value: '1h' },
   { label: 'Last 4h', value: '4h' },
   { label: 'Last 12h', value: '12h' },
   { label: 'Last 24h', value: '24h' },
   { label: 'Last 7d', value: '7d' },
+  { label: 'Custom', value: CUSTOM_VALUE },
 ];
+
+function toLocalInputValue(date: Date): string {
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
+}
+
+function localInputToIso(value: string): string {
+  return new Date(value).toISOString();
+}
+
+function isoToLocalInput(iso: string): string {
+  const date = new Date(iso);
+  return Number.isNaN(date.getTime()) ? '' : toLocalInputValue(date);
+}
 
 export function useTimeRange() {
   const [searchParams] = useSearchParams();
+  const from = searchParams.get('from') || undefined;
+  const to = searchParams.get('to') || undefined;
   const range = searchParams.get('range') || '24h';
   const hoursMap: Record<string, number> = { '1h': 1, '4h': 4, '12h': 12, '24h': 24, '7d': 168 };
-  return { range, hours: hoursMap[range] || 24 };
+
+  if (from && to) {
+    return { range, hours: hoursMap[range] || 24, from, to };
+  }
+
+  return { range, hours: hoursMap[range] || 24, from: undefined, to: undefined };
 }
 
 export default function TimeRangePicker() {
   const [searchParams, setSearchParams] = useSearchParams();
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
-  const current = searchParams.get('range') || '24h';
+
+  const paramFrom = searchParams.get('from');
+  const paramTo = searchParams.get('to');
+  const hasCustom = Boolean(paramFrom && paramTo);
+  const current = hasCustom ? CUSTOM_VALUE : (searchParams.get('range') || '24h');
+
+  const [fromInput, setFromInput] = useState(() => {
+    if (paramFrom) return isoToLocalInput(paramFrom);
+    const now = new Date();
+    return toLocalInputValue(new Date(now.getTime() - 24 * 60 * 60 * 1000));
+  });
+  const [toInput, setToInput] = useState(() => {
+    if (paramTo) return isoToLocalInput(paramTo);
+    return toLocalInputValue(new Date());
+  });
+
+  useEffect(() => {
+    if (paramFrom) setFromInput(isoToLocalInput(paramFrom));
+    if (paramTo) setToInput(isoToLocalInput(paramTo));
+  }, [paramFrom, paramTo]);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -34,9 +77,28 @@ export default function TimeRangePicker() {
 
   const select = (value: string) => {
     const params = new URLSearchParams(searchParams);
-    params.set('range', value);
+    if (value === CUSTOM_VALUE) {
+      params.delete('range');
+      if (fromInput && toInput) {
+        params.set('from', localInputToIso(fromInput));
+        params.set('to', localInputToIso(toInput));
+      }
+    } else {
+      params.set('range', value);
+      params.delete('from');
+      params.delete('to');
+      setOpen(false);
+    }
     setSearchParams(params);
-    setOpen(false);
+  };
+
+  const applyCustom = () => {
+    if (!fromInput || !toInput) return;
+    const params = new URLSearchParams(searchParams);
+    params.delete('range');
+    params.set('from', localInputToIso(fromInput));
+    params.set('to', localInputToIso(toInput));
+    setSearchParams(params);
   };
 
   const currentLabel = presets.find(p => p.value === current)?.label || current;
@@ -52,7 +114,7 @@ export default function TimeRangePicker() {
         <ChevronDown className="w-3 h-3" />
       </button>
       {open && (
-        <div className="absolute right-0 top-full mt-1 glass-strong rounded-lg shadow-xl py-1 min-w-[140px] z-50">
+        <div className="absolute right-0 top-full mt-1 glass-strong rounded-lg shadow-xl py-1 min-w-[280px] z-50">
           {presets.map(p => (
             <button
               key={p.value}
@@ -65,6 +127,37 @@ export default function TimeRangePicker() {
               {p.label}
             </button>
           ))}
+
+          {current === CUSTOM_VALUE && (
+            <div className="px-3 pt-2 pb-1 border-t border-white/10 mt-1 space-y-2">
+              <label className="block text-[11px] text-gray-400">
+                From
+                <input
+                  type="datetime-local"
+                  value={fromInput}
+                  onChange={(e) => setFromInput(e.target.value)}
+                  className="mt-1 w-full bg-slate-800 border border-slate-600 rounded-lg px-2 py-1.5 text-xs text-gray-200"
+                />
+              </label>
+              <label className="block text-[11px] text-gray-400">
+                To
+                <input
+                  type="datetime-local"
+                  value={toInput}
+                  onChange={(e) => setToInput(e.target.value)}
+                  className="mt-1 w-full bg-slate-800 border border-slate-600 rounded-lg px-2 py-1.5 text-xs text-gray-200"
+                />
+              </label>
+              <button
+                type="button"
+                onClick={applyCustom}
+                disabled={!fromInput || !toInput}
+                className="w-full rounded-lg bg-blue-500/20 text-blue-300 hover:bg-blue-500/30 disabled:opacity-50 disabled:cursor-not-allowed px-2 py-1.5 text-xs"
+              >
+                Apply
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/pages/ExecStatsPage.tsx
+++ b/frontend/src/pages/ExecStatsPage.tsx
@@ -23,6 +23,8 @@ export default function ExecStatsPage() {
   const [sortKey, setSortKey] = useState<SortKey>('total_worker_time');
   const [sortAsc, setSortAsc] = useState(false);
   const [hours, setHours] = useState(24);
+  const [objectFilter, setObjectFilter] = useState('');
+  const inputCls = 'bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-gray-300 focus:outline-none focus:border-blue-500/50';
 
   useEffect(() => {
     api.instances().then(i => setInstances(Array.isArray(i) ? i : [])).catch(() => {});
@@ -44,14 +46,23 @@ export default function ExecStatsPage() {
     total_dur_ms: Math.round((d.total_elapsed_time ?? 0) / 1000),
   })), [data]);
 
+  const filtered = useMemo(() => {
+    const q = objectFilter.trim().toLowerCase();
+    if (!q) return enriched;
+    return enriched.filter((row) => {
+      const objectName = String((row as { objectName?: string | null }).objectName ?? row.object_name ?? '').toLowerCase();
+      return objectName.includes(q);
+    });
+  }, [enriched, objectFilter]);
+
   const sorted = useMemo(() => {
-    const s = [...enriched].sort((a, b) => {
+    const s = [...filtered].sort((a, b) => {
       const av = a[sortKey] ?? 0;
       const bv = b[sortKey] ?? 0;
       return sortAsc ? (av > bv ? 1 : -1) : (av < bv ? 1 : -1);
     });
     return s;
-  }, [enriched, sortKey, sortAsc]);
+  }, [filtered, sortKey, sortAsc]);
 
   const top10 = useMemo(() =>
     [...enriched].sort((a, b) => b.total_cpu_ms - a.total_cpu_ms).slice(0, 10)
@@ -85,13 +96,32 @@ export default function ExecStatsPage() {
           </div>
         </div>
         <div className="flex items-center gap-3">
-          <select value={hours} onChange={e => setHours(Number(e.target.value))} className="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-gray-300">
+          <select value={hours} onChange={e => setHours(Number(e.target.value))} className={inputCls}>
             <option value={1}>1h</option><option value={6}>6h</option><option value={12}>12h</option><option value={24}>24h</option><option value={72}>3d</option><option value={168}>7d</option><option value={336}>14d</option>
           </select>
-          <select value={selectedInstance ?? ''} onChange={e => setSelectedInstance(e.target.value ? Number(e.target.value) : undefined)} className="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-gray-300">
+          <select value={selectedInstance ?? ''} onChange={e => setSelectedInstance(e.target.value ? Number(e.target.value) : undefined)} className={inputCls}>
             <option value="">All Instances</option>
             {instances.map((inst) => <option key={inst.InstanceID} value={inst.InstanceID}>{inst.InstanceDisplayName || inst.Instance || inst.InstanceID}</option>)}
           </select>
+          <div className="relative">
+            <input
+              type="text"
+              value={objectFilter}
+              onChange={(e) => setObjectFilter(e.target.value)}
+              placeholder="Filter by object name..."
+              className={`${inputCls} pr-8 w-56`}
+            />
+            {objectFilter && (
+              <button
+                type="button"
+                onClick={() => setObjectFilter('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white text-xs"
+                aria-label="Clear object name filter"
+              >
+                ✕
+              </button>
+            )}
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add client-side object name filter input on Exec Stats page (case-insensitive, clearable)
- add **Custom** option to TimeRangePicker with From/To datetime-local controls
- when custom range is applied, write `from`/`to` query params and clear `range`
- extend `useTimeRange()` to return `{ range, hours, from?, to? }` with custom params exposed
- add backend support for optional `from`/`to` on key performance endpoints

## Backend endpoints updated
- `/api/performance/exec-stats`
- `/api/performance/waits-timeline`
- `/api/performance/counters`
- `/api/performance/slow-queries`

Each endpoint now uses `SnapshotDate`/timestamp `BETWEEN @from AND @to` when both params are provided, otherwise falls back to existing `DATEADD(hour, -@hours, GETUTCDATE())` behavior.

## Validation
- `cd frontend && npm run build 2>&1 | tail -8` ✅