### PR TITLE
fix(alerts): require explicit instance selection on page load (#69)

### DIFF
--- a/backend/Endpoints/InstanceEndpointMappings.cs
+++ b/backend/Endpoints/InstanceEndpointMappings.cs
@@ -265,11 +265,24 @@ public static class InstanceEndpointMappings
             }
         }).RequireAuthorization();
 
-        endpoints.MapGet("/api/alerts/recent", async (ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        endpoints.MapGet("/api/alerts/recent", async (int? instanceId, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
         {
             try
             {
+                if (instanceId is int requestedInstanceId)
+                {
+                    var deny = await user.EnsureInstanceAccessAsync(requestedInstanceId, sql, cancellationToken);
+                    if (deny is not null)
+                    {
+                        return deny;
+                    }
+                }
+
                 var (errorsScope, errorsScopeParams) = user.ScopedInstanceFilter("e.InstanceID");
+                var instanceFilter = instanceId.HasValue ? " AND e.InstanceID = @instanceId" : string.Empty;
+                var errorParams = instanceId.HasValue
+                    ? errorsScopeParams.Append(("@instanceId", (object?)instanceId.Value)).ToArray()
+                    : errorsScopeParams;
                 var errors = await sql.QueryAsync($"""
                     SELECT TOP 100 e.InstanceID,
                            COALESCE(i.InstanceDisplayName, i.Instance, CAST(e.InstanceID AS VARCHAR)) AS InstanceName,
@@ -277,14 +290,18 @@ public static class InstanceEndpointMappings
                            'error' AS AlertType
                     FROM dbo.CollectionErrorLog e
                     LEFT JOIN dbo.Instances i ON e.InstanceID = i.InstanceID
-                    WHERE 1=1 {errorsScope}
+                    WHERE 1=1 {errorsScope}{instanceFilter}
                     ORDER BY e.ErrorDate DESC
-                    """, cancellationToken, errorsScopeParams);
+                    """, cancellationToken, errorParams);
 
                 List<Dictionary<string, object?>> failedJobs = [];
                 try
                 {
                     var (jobsScope, jobsScopeParams) = user.ScopedInstanceFilter("jh.InstanceID");
+                    var jobsInstanceFilter = instanceId.HasValue ? " AND jh.InstanceID = @instanceId" : string.Empty;
+                    var jobParams = instanceId.HasValue
+                        ? jobsScopeParams.Append(("@instanceId", (object?)instanceId.Value)).ToArray()
+                        : jobsScopeParams;
                     failedJobs = await sql.QueryAsync($"""
                         SELECT TOP 50 jh.InstanceID,
                                COALESCE(i.InstanceDisplayName, i.Instance) AS InstanceName,
@@ -295,9 +312,9 @@ public static class InstanceEndpointMappings
                         FROM dbo.JobHistory jh
                         JOIN dbo.Instances i ON jh.InstanceID = i.InstanceID
                         WHERE jh.run_status = 0 AND jh.RunDateTime > DATEADD(hour, -48, GETUTCDATE())
-                          {jobsScope}
+                          {jobsScope}{jobsInstanceFilter}
                         ORDER BY jh.RunDateTime DESC
-                        """, cancellationToken, jobsScopeParams);
+                        """, cancellationToken, jobParams);
                 }
                 catch
                 {

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -136,7 +136,12 @@ export const api = {
   instanceJobs: (id: number) => request<InstanceJobRow[]>(`/api/instances/${id}/jobs`),
   jobsRecent: (instanceId?: number) => request<InstanceJobRow[]>(`/api/jobs/recent${instanceId ? `?instanceId=${instanceId}` : ''}`),
   jobsFailures: (instanceId?: number) => request<ApiRow[]>(`/api/jobs/failures${instanceId ? `?instanceId=${instanceId}` : ''}`),
-  alertsRecent: () => request<ApiRow[]>('/api/alerts/recent'),
+  alertsRecent: (instanceId?: number) =>
+    request<ApiRow[]>(
+      typeof instanceId === 'number'
+        ? `/api/alerts/recent?instanceId=${instanceId}`
+        : '/api/alerts/recent',
+    ),
   availabilityGroups: () => request<AvailabilityGroupSummaryRow[]>('/api/availability-groups'),
   instanceHadr: (id: number) => request<InstanceHadrResponse>(`/api/instances/${id}/hadr`),
   hadrOverview: () => request<HadrOverviewResponse>('/api/hadr/overview'),

--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { api } from '../api/api';
+import { api, type InstanceListRow } from '../api/api';
 import { useRefresh } from '../App';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { motion, AnimatePresence } from 'framer-motion';
@@ -86,19 +86,40 @@ export default function AlertsPage() {
   const { lastRefresh } = useRefresh();
   const navigate = useNavigate();
   const [raw, setRaw] = useState<any[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
   const [search, setSearch] = useState('');
   const [sevFilter, setSevFilter] = useState<Severity | 'all'>('all');
   const [statusFilter, setStatusFilter] = useState<AlertStatus | 'all'>('open');
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
 
+  // Instance selector — '' = nothing chosen yet (initial state, no fetch)
+  // 'all' = fetch across the whole fleet (explicit opt-in, may be slow)
+  // numeric id (as string) = single instance
+  const [instanceChoice, setInstanceChoice] = useState<string>('');
+  const [instances, setInstances] = useState<InstanceListRow[]>([]);
+  const [instancesLoading, setInstancesLoading] = useState(true);
+
   useEffect(() => {
+    setInstancesLoading(true);
+    api.instances()
+      .then(rows => setInstances(Array.isArray(rows) ? rows : []))
+      .catch(() => setInstances([]))
+      .finally(() => setInstancesLoading(false));
+  }, []);
+
+  useEffect(() => {
+    if (instanceChoice === '') {
+      // Nothing chosen yet — don't hammer the backend on page load
+      setRaw([]);
+      return;
+    }
     setLoading(true);
-    api.alertsRecent()
+    const instanceId = instanceChoice === 'all' ? undefined : Number(instanceChoice);
+    api.alertsRecent(instanceId)
       .then(d => setRaw(Array.isArray(d) ? d : []))
       .catch(() => setRaw([]))
       .finally(() => setLoading(false));
-  }, [lastRefresh]);
+  }, [lastRefresh, instanceChoice]);
 
   const alerts = useMemo(() => raw.map(parseAlert).sort((a, b) => b.date.getTime() - a.date.getTime()), [raw]);
 
@@ -130,12 +151,61 @@ export default function AlertsPage() {
     return Array.from(m.entries()).sort((a, b) => b[1] - a[1]);
   }, [filtered]);
 
+  const instanceSelector = (
+    <div className="flex items-center gap-2 flex-wrap">
+      <label htmlFor="alerts-instance-select" className="text-xs text-gray-400 flex items-center gap-1.5">
+        <Server className="w-3.5 h-3.5" />
+        Instance
+      </label>
+      <select
+        id="alerts-instance-select"
+        value={instanceChoice}
+        onChange={e => { setInstanceChoice(e.target.value); setSelectedIdx(null); }}
+        disabled={instancesLoading}
+        className="bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none focus:border-blue-500/50 disabled:opacity-50"
+      >
+        <option value="">— select an instance —</option>
+        <option value="all">All instances (slow)</option>
+        {instances.map(i => (
+          <option key={i.InstanceID} value={String(i.InstanceID)}>
+            {i.InstanceDisplayName || i.Instance}
+          </option>
+        ))}
+      </select>
+      {instanceChoice === 'all' && (
+        <span className="text-[11px] text-yellow-400/80 inline-flex items-center gap-1">
+          <AlertTriangle className="w-3 h-3" />
+          Loading alerts across all instances may take several seconds.
+        </span>
+      )}
+    </div>
+  );
+
+  if (instanceChoice === '') {
+    return (
+      <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Alerts & Errors</h1>
+          <p className="text-xs text-gray-500 mt-1">Pick a server to load its alerts — or choose <span className="text-gray-300">All instances</span> for the full fleet (slower).</p>
+        </div>
+        <div className="glass rounded-2xl p-6">{instanceSelector}</div>
+        <div className="glass rounded-2xl p-16 flex flex-col items-center gap-3">
+          <Server className="w-12 h-12 text-gray-600" />
+          <p className="text-sm text-gray-400">Select an instance above to load alerts.</p>
+        </div>
+      </motion.div>
+    );
+  }
+
   if (loading) return <LoadingSpinner />;
 
   if (alerts.length === 0) {
     return (
       <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-6">
-        <h1 className="text-2xl font-bold text-white">Alerts & Errors</h1>
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <h1 className="text-2xl font-bold text-white">Alerts & Errors</h1>
+          {instanceSelector}
+        </div>
         <div className="glass rounded-2xl p-16 flex flex-col items-center gap-4">
           <Inbox className="w-16 h-16 text-gray-600" />
           <p className="text-lg font-medium text-gray-400">Keine Alerts — alles im grünen Bereich!</p>
@@ -153,6 +223,7 @@ export default function AlertsPage() {
           <h1 className="text-2xl font-bold text-white">Alerts & Errors</h1>
           <p className="text-xs text-gray-500 mt-1">Collection-Fehler und fehlgeschlagene Jobs · neueste zuerst · Auto-Refresh 30s</p>
         </div>
+        {instanceSelector}
       </div>
 
       {/* Filter Strip */}


### PR DESCRIPTION
Closes #69 — thanks @edwillis777 for the report and the screenshot.

## Change

The Alerts page now opens with an instance picker and only fetches once the user picks a specific instance — or explicitly opts into "All instances (slow)" with a visible warning. No more multi-second wait on first navigation.

### Backend
- `/api/alerts/recent` accepts an optional `instanceId` query param
- When supplied: scope-checked (403 if denied) and applied to both the CollectionErrorLog and JobHistory queries

### Frontend
- AlertsPage shows a server selector with all instances + opt-in "All instances" choice
- No fetch happens until the user picks something
- Refresh/auto-refresh flow updated to honour the selection

## Verification
- `dotnet build` clean, `dotnet test backend.tests` 12/12 green
- Frontend tsc clean