### PR TITLE
fix(frontend): import InstanceListRow from types directly

### DIFF
--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { api, type InstanceListRow } from '../api/api';
+import { api } from '../api/api';
+import type { InstanceListRow } from '../api/types';
 import { useRefresh } from '../App';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { motion, AnimatePresence } from 'framer-motion';


### PR DESCRIPTION
Follow-up to #72 — CI build broke because `InstanceListRow` was imported via `../api/api` where it is only used internally and not re-exported. Switched the import to come straight from `../api/types`. Build clean now.