### PR TITLE
fix(api): resolve InstanceID via Drives join in drive performance query (#74)

### DIFF
--- a/backend/Endpoints/PerformanceEndpointMappings.cs
+++ b/backend/Endpoints/PerformanceEndpointMappings.cs
@@ -308,13 +308,22 @@ public static class PerformanceEndpointMappings
 
             try
             {
-                var (scopeSnippet, scopeParameters) = user.ScopedInstanceFilter("dp.InstanceID");
-                var filter = instanceId.HasValue ? "AND dp.InstanceID = @instanceId" : string.Empty;
+                var (scopeSnippet, scopeParameters) = user.ScopedInstanceFilter("dr.InstanceID");
+                var filter = instanceId.HasValue ? "AND dr.InstanceID = @instanceId" : string.Empty;
+                // DriveSnapshot has no InstanceID column — join via Drives to resolve the instance.
                 var query = $"""
-                    SELECT TOP 200 dp.*,
+                    SELECT TOP 200 dr.InstanceID,
+                           dr.DriveID,
+                           dr.Name AS DriveName,
+                           dr.Label AS DriveLabel,
+                           dp.SnapshotDate,
+                           dp.Capacity,
+                           dp.FreeSpace,
+                           dp.UsedSpace,
                            COALESCE(i.InstanceDisplayName, i.Instance) AS InstanceDisplayName
                     FROM dbo.DriveSnapshot dp
-                    JOIN dbo.Instances i ON dp.InstanceID = i.InstanceID
+                    JOIN dbo.Drives dr ON dp.DriveID = dr.DriveID
+                    JOIN dbo.Instances i ON dr.InstanceID = i.InstanceID
                     WHERE dp.SnapshotDate > DATEADD(hour, -@hours, GETUTCDATE()) {filter} {scopeSnippet}
                     ORDER BY dp.SnapshotDate DESC
                     """;


### PR DESCRIPTION
Closes #74.

The `DriveSnapshot` table doesn't have an `InstanceID` column — its schema is just `(SnapshotDate, DriveID, Capacity, FreeSpace, UsedSpace)` with `InstanceID` on `dbo.Drives`. The drive section of `/api/performance/io-stats` was selecting `dp.*` and joining `Instances` on `dp.InstanceID`, which blew up with `Invalid column name 'InstanceID'.` and surfaced as `DriveSnapshot not found: Invalid column name InstanceID.` on the I/O Performance page.

Fix joins through `dbo.Drives` to resolve `InstanceID`, applies both the optional instance filter and the scoped permission filter against `dr.InstanceID`, and projects explicit columns (snapshot fields plus drive name/label) instead of `dp.*` so the frontend can render per-drive rows.

Verified `dotnet build` is clean.