### PR TITLE
ci: pin runner to windows-2025

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   validate:
-    runs-on: windows-latest
+    runs-on: windows-2025
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GitHub announced that `windows-latest` will be redirected to `windows-2025-vs2026` by June 15, 2026 (we just saw the notice on the v0.2.2 build run). Pinning explicitly to `windows-2025` so the runner image swap doesn't silently change toolchain versions on us — we can deliberately bump to `windows-2025-vs2026` once we've validated the build there.