### PR TITLE
Upgrade backend to .NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup .NET 8
+      - name: Setup .NET 10
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '8.0.x'
+          dotnet-version: '10.0.x'
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/backend.tests/DBADashWebView.Tests.csproj
+++ b/backend.tests/DBADashWebView.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/backend/DBADashWebView.csproj
+++ b/backend/DBADashWebView.csproj
@@ -1,16 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.12" />
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.24" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
-    <PackageReference Include="System.DirectoryServices.Protocols" Version="8.0.1" />
+    <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Upgrades the backend from .NET 8 to .NET 10 to address the security advisories called out in #80.

## Changes

- **`backend/DBADashWebView.csproj`**
  - `TargetFramework`: `net8.0` → `net10.0`
  - `Microsoft.AspNetCore.Authentication.JwtBearer`: `8.0.12` → `10.0.9`
  - `Microsoft.AspNetCore.OpenApi`: `8.0.24` → `10.0.9`
  - `System.DirectoryServices.Protocols`: `8.0.1` → `10.0.9`
  - `Microsoft.Data.SqlClient` (6.1.4) and `Swashbuckle.AspNetCore` (6.6.2) left as-is — both already compatible with .NET 10.
- **`backend.tests/DBADashWebView.Tests.csproj`**
  - `TargetFramework`: `net8.0` → `net10.0` (xunit + test SDK versions stay)
- **`.github/workflows/build.yml`**
  - `actions/setup-dotnet` `dotnet-version`: `8.0.x` → `10.0.x` (step label updated too)
- `backend/web.config` left untouched — `AspNetCoreModuleV2` is runtime-version-agnostic, so IIS deployments keep working.

## Verified locally

With .NET 10 SDK `10.0.301`:

```
dotnet restore backend/DBADashWebView.csproj            # OK
dotnet build   backend/DBADashWebView.csproj -c Release # 0 warnings, 0 errors
dotnet test    backend.tests -c Release                 # 12/12 passed
```

CI will validate the full Windows publish + frontend e2e path.

Closes #80
