### PR TITLE
fix(backend): bump Swashbuckle.AspNetCore to 10.2.1 (fixes #80 startup crash)

### DIFF
--- a/backend/DBADashWebView.csproj
+++ b/backend/DBADashWebView.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.9" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="6.1.4" />
     <PackageReference Include="System.DirectoryServices.Protocols" Version="10.0.9" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #80 (startup crash).

## Problem

After the .NET 10 upgrade (#81), the backend crashes on first request with:

```
System.TypeLoadException: Method 'GetSwagger' in type 'Swashbuckle.AspNetCore.SwaggerGen.SwaggerGenerator'
from assembly 'Swashbuckle.AspNetCore.SwaggerGen, Version=6.6.2.0, ...' does not have an implementation.
   at Microsoft.Extensions.DependencyInjection.SwaggerGenServiceCollectionExtensions.AddSwaggerGen(...)
   at Program.<Main>$(String[] args) in backend/Program.cs:line 56
```

That's what was hiding behind Ed's HTTP 500 on login — the host fails to start, IIS just surfaces ANCM 500.

## Cause

`Microsoft.AspNetCore.OpenApi` 10.0.9 transitively pulls in `Microsoft.OpenApi` 2.0, which reorganised the `Microsoft.OpenApi.Models` namespace. Swashbuckle 6.6.2 was built against `Microsoft.OpenApi` 1.x and its `SwaggerGenerator.GetSwagger` signature no longer resolves at load time. Upstream tracking issue: domaindrivendev/Swashbuckle.AspNetCore#3522.

## Fix

Bump `Swashbuckle.AspNetCore` to **10.2.1**, the first major release built against `Microsoft.OpenApi` 2.0 and targeting `net10.0`. Public API (`AddSwaggerGen`, `UseSwagger`, `UseSwaggerUI`) is source-compatible, so `Program.cs` doesn't need any code changes.

## Test plan

- [x] Diff is a single `PackageReference` version bump
- [ ] CI `Build, Test & Package` workflow green
- [ ] Manual login on Ed's deployment no longer 500s