### PR TITLE
Mobile-optimized views for on-call DBAs (#92)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { Suspense, createContext, lazy, useContext, useEffect, useMemo, useState } from 'react';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AnimatePresence, motion } from 'framer-motion';
-import { Moon, RefreshCw, Sun } from 'lucide-react';
+import { Menu, Moon, RefreshCw, Sun } from 'lucide-react';
 import { api, clearToken, isAuthenticated } from './api/api';
 import { hasRole } from './auth/session';
 import type { AuthRole } from './auth/session';
@@ -95,6 +95,7 @@ function Layout({ children }: { children: React.ReactNode }) {
   const location = useLocation();
   const { lastRefresh, refresh } = useRefresh();
   const { dark, toggle: toggleTheme } = useTheme();
+  const [mobileNavOpen, setMobileNavOpen] = useState(false);
   const [searchData, setSearchData] = useState<{ instances: SearchInstanceRow[]; databases: []; jobs: SearchJobRow[] }>({
     instances: [],
     databases: [],
@@ -145,16 +146,78 @@ function Layout({ children }: { children: React.ReactNode }) {
     navigate('/login');
   };
 
+  // Close drawer on route change
+  useEffect(() => {
+    setMobileNavOpen(false);
+  }, [location.pathname]);
+
+  // Close drawer on Esc
+  useEffect(() => {
+    if (!mobileNavOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setMobileNavOpen(false);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [mobileNavOpen]);
+
   return (
     <div className="flex h-screen overflow-hidden">
       <SearchDialog instances={searchData.instances} databases={searchData.databases} jobs={searchData.jobs} />
 
-      <InstanceTree onLogout={handleLogout} />
+      {/* Desktop sidebar */}
+      <div className="hidden md:flex shrink-0">
+        <InstanceTree onLogout={handleLogout} />
+      </div>
+
+      {/* Mobile drawer */}
+      <AnimatePresence>
+        {mobileNavOpen && (
+          <>
+            <motion.div
+              key="drawer-backdrop"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.15 }}
+              onClick={() => setMobileNavOpen(false)}
+              className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm md:hidden"
+              aria-hidden="true"
+            />
+            <motion.div
+              key="drawer-panel"
+              initial={{ x: '-100%' }}
+              animate={{ x: 0 }}
+              exit={{ x: '-100%' }}
+              transition={{ type: 'tween', duration: 0.2, ease: 'easeOut' }}
+              className="fixed inset-y-0 left-0 z-50 flex md:hidden"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Navigation"
+            >
+              <InstanceTree
+                onLogout={handleLogout}
+                onNavigate={() => setMobileNavOpen(false)}
+                variant="drawer"
+              />
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
 
       <div className="flex flex-1 flex-col overflow-hidden">
-        <header className="glass-strong z-10 flex h-14 shrink-0 items-center justify-between border-b border-white/10 px-6">
-          <Breadcrumbs />
-          <div className="flex items-center gap-2">
+        <header className="glass-strong z-10 flex h-14 shrink-0 items-center justify-between border-b border-white/10 px-3 md:px-6">
+          <div className="flex items-center gap-2 min-w-0">
+            <button
+              onClick={() => setMobileNavOpen(true)}
+              className="-ml-1 rounded-lg p-2 text-gray-300 transition-all hover:bg-white/5 hover:text-white md:hidden"
+              aria-label="Open navigation"
+            >
+              <Menu className="h-5 w-5" />
+            </button>
+            <Breadcrumbs />
+          </div>
+          <div className="flex items-center gap-1.5 md:gap-2">
             <button
               onClick={triggerSearch}
               className="hidden items-center gap-2 rounded-lg bg-white/5 px-3 py-1.5 text-xs text-gray-500 transition-all hover:bg-white/10 sm:flex"
@@ -169,7 +232,7 @@ function Layout({ children }: { children: React.ReactNode }) {
             >
               {dark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </button>
-            <div className="flex items-center gap-2 text-xs text-gray-500">
+            <div className="hidden sm:flex items-center gap-2 text-xs text-gray-500">
               {lastRefresh.toLocaleTimeString()}
             </div>
             <button
@@ -181,7 +244,7 @@ function Layout({ children }: { children: React.ReactNode }) {
           </div>
         </header>
 
-        <main className="flex-1 overflow-y-auto p-6">
+        <main className="flex-1 overflow-y-auto p-3 md:p-6">
           <AnimatePresence mode="wait">
             <motion.div
               key={location.pathname}

--- a/frontend/src/components/InstanceTree.tsx
+++ b/frontend/src/components/InstanceTree.tsx
@@ -26,7 +26,13 @@ const instanceCategories = [
   { key: 'reports', icon: BarChart3, label: 'Reports', path: (id: number) => `/instances/${id}/reports` },
 ];
 
-export default function InstanceTree({ onLogout }: { onLogout: () => void }) {
+interface InstanceTreeProps {
+  onLogout: () => void;
+  onNavigate?: () => void;
+  variant?: 'sidebar' | 'drawer';
+}
+
+export default function InstanceTree({ onLogout, onNavigate, variant = 'sidebar' }: InstanceTreeProps) {
   const [instances, setInstances] = useState<TreeInstanceNode[]>([]);
   const [expandedVersions, setExpandedVersions] = useState<Set<string>>(() => {
     try {
@@ -111,8 +117,14 @@ export default function InstanceTree({ onLogout }: { onLogout: () => void }) {
     return false;
   };
 
+  const handleNavClick = () => {
+    if (onNavigate) onNavigate();
+  };
+
+  const widthClass = variant === 'drawer' ? 'w-[85vw] max-w-xs' : 'w-72';
+
   return (
-    <div className="w-72 bg-slate-900/95 border-r border-white/10 flex flex-col h-full shrink-0">
+    <div className={`${widthClass} bg-slate-900/95 border-r border-white/10 flex flex-col h-full shrink-0`}>
       {/* Header */}
       <div className="p-4 flex items-center gap-3 border-b border-white/10">
         <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center shrink-0">
@@ -122,7 +134,7 @@ export default function InstanceTree({ onLogout }: { onLogout: () => void }) {
       </div>
 
       <div className="flex-1 overflow-y-auto" style={{ scrollbarWidth: 'thin', scrollbarColor: '#475569 transparent' }}>
-        <NavMenu />
+        <NavMenu onNavigate={handleNavClick} />
 
         {/* SQL Servers grouped by version */}
         <div className="px-3 py-2">
@@ -197,6 +209,7 @@ export default function InstanceTree({ onLogout }: { onLogout: () => void }) {
                                           </button>
                                           {sysExpanded && systemDbs.map(db => (
                                             <Link key={db.databaseId} to={`/instances/${inst.instanceId}/databases/${db.databaseId}`}
+                                              onClick={handleNavClick}
                                               className={`flex items-center gap-2 py-0.5 pl-10 pr-2 rounded text-xs transition-all ${
                                                 isActive(`/instances/${inst.instanceId}/databases/${db.databaseId}`)
                                                   ? 'bg-blue-500/15 text-blue-400' : 'text-gray-500 hover:text-gray-300 hover:bg-white/5'
@@ -209,6 +222,7 @@ export default function InstanceTree({ onLogout }: { onLogout: () => void }) {
                                       )}
                                       {userDbs.map(db => (
                                         <Link key={db.databaseId} to={`/instances/${inst.instanceId}/databases/${db.databaseId}`}
+                                          onClick={handleNavClick}
                                           className={`flex items-center gap-2 py-0.5 pl-4 pr-2 rounded text-xs transition-all ${
                                             isActive(`/instances/${inst.instanceId}/databases/${db.databaseId}`)
                                               ? 'bg-blue-500/15 text-blue-400' : 'text-gray-500 hover:text-gray-300 hover:bg-white/5'
@@ -226,6 +240,7 @@ export default function InstanceTree({ onLogout }: { onLogout: () => void }) {
                             const path = cat.path(inst.instanceId);
                             return (
                               <Link key={cat.key} to={path}
+                                onClick={handleNavClick}
                                 className={`flex items-center gap-2 py-1 pl-4 pr-2 rounded text-sm transition-all ${
                                   isActive(path)
                                     ? 'bg-blue-500/15 text-blue-400 border-l-2 border-blue-400'

--- a/frontend/src/components/NavMenu.tsx
+++ b/frontend/src/components/NavMenu.tsx
@@ -148,7 +148,7 @@ function isPathActive(currentPath: string, targetPath: string) {
   return currentPath === targetPath || currentPath.startsWith(`${targetPath}/`);
 }
 
-export default function NavMenu() {
+export default function NavMenu({ onNavigate }: { onNavigate?: () => void } = {}) {
   const location = useLocation();
   const isAdmin = hasRole(['Admin']);
 
@@ -221,6 +221,7 @@ export default function NavMenu() {
                       <Link
                         key={item.path}
                         to={item.path}
+                        onClick={onNavigate}
                         className={`flex items-center gap-2 py-1 px-2 rounded text-sm transition-all border-l-2 ${
                           active
                             ? 'bg-blue-500/15 text-blue-400 border-blue-400'

--- a/frontend/src/components/TabNav.tsx
+++ b/frontend/src/components/TabNav.tsx
@@ -8,13 +8,13 @@ interface Tab {
 
 export default function TabNav({ tabs, active, onChange }: { tabs: Tab[]; active: string; onChange: (key: string) => void }) {
   return (
-    <div className="tabnav-container flex gap-1 p-1 rounded-lg w-fit">
+    <div className="tabnav-container flex gap-1 p-1 rounded-lg max-w-full overflow-x-auto whitespace-nowrap scrollbar-thin">
       {tabs.map(tab => (
         <button
           key={tab.key}
           onClick={() => onChange(tab.key)}
           className={clsx(
-            'px-4 py-2 text-sm font-medium rounded-md transition-all',
+            'px-4 py-2 text-sm font-medium rounded-md transition-all flex-shrink-0',
             active === tab.key
               ? 'bg-blue-500/20 text-blue-400 shadow-sm'
               : 'tabnav-inactive text-gray-400 hover:text-gray-200'

--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -249,7 +249,7 @@ export default function AlertsPage() {
           ))}
         </div>
 
-        <div className="flex flex-wrap gap-3">
+        <div className="flex flex-wrap gap-2 md:gap-3">
           {([
             { key: 'all' as const, label: 'Severity: All', count: counts.total, color: 'text-white', bg: 'bg-white/5' },
             { key: 'critical' as const, label: 'Critical', count: counts.critical, color: SEV_CONFIG.critical.color, bg: SEV_CONFIG.critical.bg },
@@ -260,11 +260,11 @@ export default function AlertsPage() {
               key={k.key}
               onClick={() => setSevFilter(sevFilter === k.key ? 'all' : k.key)}
               className={clsx(
-                'flex items-center gap-2 px-4 py-2 rounded-xl text-sm transition-all border',
+                'flex items-center gap-2 px-3 py-1.5 md:px-4 md:py-2 rounded-xl text-sm transition-all border',
                 sevFilter === k.key ? `${k.bg} border-current ${k.color}` : 'bg-white/5 border-white/5 text-gray-400 hover:bg-white/10'
               )}
             >
-              <span className={clsx('text-lg font-bold', k.color)}>{k.count}</span>
+              <span className={clsx('text-base md:text-lg font-bold', k.color)}>{k.count}</span>
               <span>{k.label}</span>
             </button>
           ))}
@@ -292,9 +292,9 @@ export default function AlertsPage() {
       </div>
 
       {/* Main Grid: Alert List + Detail */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-5">
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 md:gap-5">
         {/* Alert List */}
-        <div className="lg:col-span-2 space-y-1 max-h-[72vh] overflow-y-auto pr-1 scrollbar-thin">
+        <div className="lg:col-span-2 space-y-1 lg:max-h-[72vh] lg:overflow-y-auto pr-0 lg:pr-1 scrollbar-thin">
           <AnimatePresence initial={false}>
             {filtered.map((a, i) => {
               const cfg = SEV_CONFIG[a.severity];
@@ -364,7 +364,7 @@ export default function AlertsPage() {
         {/* Detail Panel */}
         <div className="space-y-4">
           {/* Selected Alert Detail */}
-          <div className="glass rounded-2xl p-6 sticky top-4">
+          <div className="glass rounded-2xl p-4 md:p-6 lg:sticky lg:top-4">
             {selected ? (() => {
               const cfg = SEV_CONFIG[selected.severity];
               const Icon = cfg.icon;

--- a/frontend/src/pages/InstanceDetailPage.tsx
+++ b/frontend/src/pages/InstanceDetailPage.tsx
@@ -193,24 +193,24 @@ export default function InstanceDetailPage() {
     <div className="space-y-6">
       {/* ── Header ─────────────────────────────────────────────────────── */}
       <motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }}
-        className="glass rounded-2xl p-6 gradient-border">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex items-center gap-4">
-            <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-blue-500/20 to-cyan-500/20 flex items-center justify-center border border-blue-500/20">
+        className="glass rounded-2xl p-4 md:p-6 gradient-border">
+        <div className="flex items-start justify-between gap-4 flex-wrap">
+          <div className="flex items-center gap-4 min-w-0">
+            <div className="w-14 h-14 rounded-2xl bg-gradient-to-br from-blue-500/20 to-cyan-500/20 flex items-center justify-center border border-blue-500/20 shrink-0">
               <Server className="w-7 h-7 text-blue-400" />
             </div>
-            <div>
-              <h1 className="text-2xl font-bold text-white tracking-tight">
+            <div className="min-w-0">
+              <h1 className="text-xl md:text-2xl font-bold text-white tracking-tight truncate">
                 {inst.InstanceDisplayName || inst.ConnectionID}
               </h1>
-              <div className="flex items-center gap-2 mt-1">
+              <div className="flex items-center gap-2 mt-1 flex-wrap">
                 <span className="text-sm text-gray-400">{inst.Edition}</span>
                 <span className="text-gray-600">·</span>
                 <span className="text-sm font-mono text-gray-500">{inst.ProductVersion}</span>
               </div>
             </div>
           </div>
-          <div className="text-right text-xs text-gray-500 space-y-1">
+          <div className="text-right text-xs text-gray-500 space-y-1 shrink-0">
             {inst.LastCollected && (
               <p className="flex items-center gap-1 justify-end">
                 <Activity className="w-3 h-3 text-emerald-400" />
@@ -227,7 +227,7 @@ export default function InstanceDetailPage() {
         </div>
 
         {/* Inline stats */}
-        <div className="grid grid-cols-4 gap-4 mt-5 pt-5 border-t border-white/5">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mt-5 pt-5 border-t border-white/5">
           <div>
             <p className="text-[11px] text-gray-500 uppercase tracking-wider">CPUs</p>
             <p className="text-lg font-semibold text-white mt-0.5">{inst.cpu_count ?? '—'}</p>
@@ -277,7 +277,7 @@ export default function InstanceDetailPage() {
             <div className="space-y-6">
               {/* CPU KPIs */}
               {cpuStats && (
-                <div className="grid grid-cols-3 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                   {[
                     { label: 'Current CPU', value: `${cpuStats.current}%`, color: cpuStats.current > 50 ? 'text-red-400' : cpuStats.current > 25 ? 'text-yellow-400' : 'text-emerald-400' },
                     { label: 'Avg (24h)', value: `${cpuStats.avg}%`, color: cpuStats.avg > 50 ? 'text-red-400' : cpuStats.avg > 25 ? 'text-yellow-400' : 'text-emerald-400' },
@@ -293,8 +293,8 @@ export default function InstanceDetailPage() {
               )}
 
               {/* CPU Chart */}
-              <div className="glass rounded-2xl p-6">
-                <div className="flex items-center justify-between mb-4">
+              <div className="glass rounded-2xl p-4 md:p-6">
+                <div className="flex items-center justify-between mb-4 gap-2 flex-wrap">
                   <h3 className="text-sm font-semibold text-white flex items-center gap-2">
                     <Cpu className="w-4 h-4 text-blue-400" /> CPU Usage ({hoursLabel(hours)})
                   </h3>
@@ -329,7 +329,7 @@ export default function InstanceDetailPage() {
               </div>
 
               {/* Waits */}
-              <div className="glass rounded-2xl p-6">
+              <div className="glass rounded-2xl p-4 md:p-6">
                 <h3 className="text-sm font-semibold text-white mb-4 flex items-center gap-2">
                   <BarChart3 className="w-4 h-4 text-amber-400" /> Top Wait Types (1h)
                 </h3>
@@ -350,13 +350,14 @@ export default function InstanceDetailPage() {
           {/* ── Backups ──────────────────────────────────────────────────── */}
           {tab === 'backups' && (
             <div className="glass rounded-2xl overflow-hidden">
-              <div className="px-6 py-4 border-b border-white/5">
+              <div className="px-4 md:px-6 py-4 border-b border-white/5">
                 <h3 className="text-sm font-semibold text-white flex items-center gap-2">
                   <Shield className="w-4 h-4 text-blue-400" /> Backup Status per Database
                 </h3>
                 <p className="text-xs text-gray-500 mt-1">AG Secondary databases show "via Primary" — backups run on the preferred replica</p>
               </div>
-              <table className="w-full text-sm">
+              <div className="overflow-x-auto">
+              <table className="w-full text-sm min-w-[640px]">
                 <thead>
                   <tr className="border-b border-white/10">
                     <th className="px-5 py-3 text-left text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Database</th>
@@ -422,6 +423,7 @@ export default function InstanceDetailPage() {
                   {backupsByDb.length === 0 && <tr><td colSpan={5} className="px-5 py-12 text-center text-gray-500">No backup data</td></tr>}
                 </tbody>
               </table>
+              </div>
             </div>
           )}
 
@@ -438,7 +440,8 @@ export default function InstanceDetailPage() {
                 onChange={(k) => setJobFilter(k as 'all' | 'failed' | 'success')}
               />
               <div className="glass rounded-2xl overflow-hidden">
-                <table className="w-full text-sm">
+                <div className="overflow-x-auto">
+                <table className="w-full text-sm min-w-[720px]">
                   <thead>
                     <tr className="border-b border-white/10">
                       <th className="px-5 py-3 text-left text-[11px] font-semibold text-gray-400 uppercase tracking-wider w-24">Status</th>
@@ -470,6 +473,7 @@ export default function InstanceDetailPage() {
                     {filteredJobs.length === 0 && <tr><td colSpan={5} className="px-5 py-12 text-center text-gray-500">No jobs</td></tr>}
                   </tbody>
                 </table>
+                </div>
               </div>
             </div>
           )}
@@ -477,7 +481,8 @@ export default function InstanceDetailPage() {
           {/* ── Databases ────────────────────────────────────────────────── */}
           {tab === 'databases' && (
             <div className="glass rounded-2xl overflow-hidden">
-              <table className="w-full text-sm">
+              <div className="overflow-x-auto">
+              <table className="w-full text-sm min-w-[760px]">
                 <thead>
                   <tr className="border-b border-white/10">
                     <th className="px-5 py-3 text-left text-[11px] font-semibold text-gray-400 uppercase tracking-wider">Name</th>
@@ -537,6 +542,7 @@ export default function InstanceDetailPage() {
                   {databases.length === 0 && <tr><td colSpan={6} className="px-5 py-12 text-center text-gray-500">No databases</td></tr>}
                 </tbody>
               </table>
+              </div>
             </div>
           )}
 

--- a/frontend/src/pages/SqlMonitorPage.tsx
+++ b/frontend/src/pages/SqlMonitorPage.tsx
@@ -71,7 +71,7 @@ function InstanceCard({ inst, onClick }: { inst: MonitorInstance; onClick: () =>
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       onClick={onClick}
-      className={`${sc.bg} border ${sc.border} rounded-lg p-3 cursor-pointer hover:bg-white/10 transition-all group min-w-[220px]`}
+      className={`${sc.bg} border ${sc.border} rounded-lg p-3 cursor-pointer hover:bg-white/10 transition-all group`}
     >
       {/* Header */}
       <div className="flex items-start justify-between mb-2">
@@ -217,7 +217,7 @@ export default function SqlMonitorPage() {
   if (loading) return <div className="flex items-center justify-center h-64"><div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-400" /></div>;
 
   return (
-    <div className="flex gap-6 min-h-[calc(100vh-120px)]">
+    <div className="flex flex-col lg:flex-row lg:gap-6 gap-4 min-h-[calc(100vh-120px)]">
       {/* Main content */}
       <div className="flex-1 space-y-4 min-w-0">
         {/* Header */}
@@ -229,11 +229,11 @@ export default function SqlMonitorPage() {
               <p className="text-xs text-gray-500">{instances.length} Instances · {ok} healthy · {warn} warning · {crit} critical</p>
             </div>
           </div>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 md:gap-3">
             <div className="relative">
               <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
               <input type="text" placeholder="Search servers..." value={search} onChange={e => setSearch(e.target.value)}
-                className="bg-white/5 border border-white/10 rounded-lg pl-9 pr-3 py-1.5 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500/50 w-48"
+                className="bg-white/5 border border-white/10 rounded-lg pl-9 pr-3 py-1.5 text-sm text-white placeholder-gray-500 focus:outline-none focus:border-blue-500/50 w-36 sm:w-48"
               />
               {search && <button onClick={() => setSearch('')} className="absolute right-2 top-1/2 -translate-y-1/2"><X className="w-3.5 h-3.5 text-gray-500" /></button>}
             </div>
@@ -277,7 +277,7 @@ export default function SqlMonitorPage() {
                 exit={{ height: 0, opacity: 0 }}
                 className="overflow-hidden"
               >
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 px-4 pb-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 px-4 pb-4">
                   {filtered.map(inst => (
                     <InstanceCard key={inst.instanceId} inst={inst} onClick={() => navigate(`/instances/${inst.instanceId}`)} />
                   ))}
@@ -291,9 +291,9 @@ export default function SqlMonitorPage() {
         </div>
       </div>
 
-      {/* Alert sidebar (right panel) */}
-      <div className="w-64 flex-shrink-0 hidden lg:block">
-        <div className="glass rounded-xl border border-white/5 p-4 sticky top-4">
+      {/* Alert sidebar (right panel on lg+, full-width on mobile) */}
+      <div className="w-full lg:w-64 flex-shrink-0">
+        <div className="glass rounded-xl border border-white/5 p-4 lg:sticky lg:top-4">
           <h2 className="text-sm font-semibold text-white mb-3">Alerts</h2>
           <div className="space-y-1">
             {alertTypes.map(at => (


### PR DESCRIPTION
## Mobile-optimized views for on-call DBAs

Implements the MVP of Epic #92 — makes the on-call surfaces (Alerts, SQL Monitor, Instance Detail) usable one-handed on a phone at 375 px.

## What changed

### Layout / chrome (`App.tsx`, `InstanceTree.tsx`, `NavMenu.tsx`)
- Sidebar (`InstanceTree`) is hidden on `<md` (`hidden md:flex`) and replaced by a hamburger button in the header that opens it as a slide-in overlay drawer (with backdrop, framer-motion).
- Drawer closes on backdrop click, on route change, and on Esc.
- Drawer width: `w-[85vw] max-w-xs` (vs `w-72` desktop). Implemented with a new `variant?: 'sidebar' | 'drawer'` prop on `InstanceTree`.
- New `onNavigate` prop on `InstanceTree` (and `NavMenu`); every `<Link>` calls it on click so tapping a tree entry closes the drawer.
- Header padding `px-3 md:px-6` (was `px-6`).
- Last-refresh timestamp text hidden `<sm` (was always visible).
- Main content padding `p-3 md:p-6` (was `p-6`).
- Search ⌘K pill stays `hidden sm:flex` as before.

### `AlertsPage.tsx`
- Already uses a card list (no real `<table>`), so no table→cards conversion needed; verified at 375 px.
- Filter chips and KPI cards already wrap; tightened padding (`px-3 py-1.5 md:px-4 md:py-2`) and counter font size (`text-base md:text-lg`) to fit two-up on mobile.
- Removed `sticky top-4` and inner `max-h-[72vh] overflow-y-auto` on small screens (only sticky/scroll on `lg+`) so the detail panel sits naturally below the list on mobile.
- Reduced gap (`gap-4 md:gap-5`) and detail-card padding (`p-4 md:p-6`) for mobile.

### `SqlMonitorPage.tsx`
- Outer container is now `flex-col lg:flex-row` so the alert sidebar drops below the grid on `<lg`.
- Alert sidebar: was `hidden lg:block` — now visible on every breakpoint (`w-full lg:w-64`) so on-call DBAs see the alerts breakdown on mobile too.
- Card grid is `grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4` (per spec — single column on mobile, 2 on md, 3 on lg, 4 on xl).
- Removed `min-w-[220px]` on `InstanceCard` to prevent overflow at 375 px / inside the drawer.
- Search input shrinks on mobile (`w-36 sm:w-48`).
- Sidebar `sticky` only on `lg+`.

### `InstanceDetailPage.tsx`
- Header KPI grid: `grid-cols-2 md:grid-cols-4` (was hard `grid-cols-4`, overflowed on mobile).
- CPU KPI sub-grid: `grid-cols-1 sm:grid-cols-3` (was `grid-cols-3`).
- All wide tables (Backups, Jobs, Databases) wrapped in `overflow-x-auto` containers with `min-w-[640..760px]` on the table itself, so the table scrolls horizontally inside its card while the page itself does not horizontal-scroll at 375 px.
- Header card and chart cards use `p-4 md:p-6` for tighter mobile spacing.
- Header layout uses `flex-wrap` so badges/timestamps reflow.

### `TabNav.tsx`
- Tab bar now scrolls horizontally instead of overflowing the page: `max-w-full overflow-x-auto whitespace-nowrap` and tabs marked `flex-shrink-0`. Fixes the 5-tab strip on Instance Detail at 375 px.

## Acceptance criteria
- [x] No horizontal page scroll on Alerts, SQL Monitor, Instance Detail at 375 px width — wide tables now scroll within their own card; KPI/grid/tab containers reflow.
- [x] Sidebar hidden on mobile, accessible via hamburger drawer.
- [x] Tapping a tree link closes the drawer (`onNavigate` wired through `InstanceTree` + `NavMenu`).
- [x] Drawer also closes on backdrop click and on Esc.
- [x] All existing tests pass (`npm run test:run` → 4 passed).
- [x] `npm run build` is green.

## Tests run
```
cd frontend
npm install --no-audit --no-fund   # ok
npm run build                       # ok
npm run test:run                    # 4/4 passed
```

E2E: skipped — repo has no playwright e2e suite that runs without a backend.

## Notes / out of scope
- PWA install prompt + offline shell (called out as stretch in the epic) — left for a follow-up.
- Pre-existing repo lint state on `main` already has 87 ESLint errors (87 errors, 5 warnings). This branch adds 1 same-pattern `react-hooks/set-state-in-effect` error (drawer auto-close on route change, mirroring conventions used throughout the codebase). Not a regression but worth flagging.

Closes part of Epic #92.
