### PR TITLE
Surface real DBA Dash tags in Groups & Tags page (#98)

### DIFF
--- a/backend.tests/TagsEndpointMappingsTests.cs
+++ b/backend.tests/TagsEndpointMappingsTests.cs
@@ -1,0 +1,109 @@
+using DBADashWebView.Endpoints;
+using Xunit;
+
+namespace DBADashWebView.Tests;
+
+public sealed class TagsEndpointMappingsTests
+{
+    private static Dictionary<string, object?> Row(int tagId, string tagName, string? tagValue, int instanceId) =>
+        new()
+        {
+            ["TagID"] = tagId,
+            ["TagName"] = tagName,
+            ["TagValue"] = tagValue,
+            ["InstanceID"] = instanceId,
+        };
+
+    [Fact]
+    public void BuildTagRows_GroupsMultipleInstancesUnderOneTag()
+    {
+        var rows = new List<Dictionary<string, object?>>
+        {
+            Row(1, "prod", "", 10),
+            Row(1, "prod", "", 11),
+            Row(1, "prod", "", 12),
+        };
+
+        var result = TagsEndpointMappings.BuildTagRows(rows, allowedInstanceIds: null);
+
+        var tag = Assert.Single(result);
+        Assert.Equal(1, tag.TagId);
+        Assert.Equal("prod", tag.TagName);
+        Assert.Equal(new[] { 10, 11, 12 }, tag.InstanceIds);
+    }
+
+    [Fact]
+    public void BuildTagRows_TagNameStartingWithBrace_IsSystem()
+    {
+        var rows = new List<Dictionary<string, object?>>
+        {
+            Row(1, "{Version}", "2019", 10),
+            Row(2, "prod", "", 10),
+        };
+
+        var result = TagsEndpointMappings.BuildTagRows(rows, allowedInstanceIds: null);
+
+        Assert.True(result.Single(t => t.TagId == 1).IsSystem);
+        Assert.False(result.Single(t => t.TagId == 2).IsSystem);
+    }
+
+    [Fact]
+    public void BuildTagRows_NullScope_IncludesAllInstances()
+    {
+        var rows = new List<Dictionary<string, object?>>
+        {
+            Row(1, "prod", "", 10),
+            Row(1, "prod", "", 20),
+        };
+
+        var result = TagsEndpointMappings.BuildTagRows(rows, allowedInstanceIds: null);
+
+        Assert.Equal(new[] { 10, 20 }, Assert.Single(result).InstanceIds);
+    }
+
+    [Fact]
+    public void BuildTagRows_ScopedInstances_FiltersOutDisallowedInstances()
+    {
+        var rows = new List<Dictionary<string, object?>>
+        {
+            Row(1, "prod", "", 10),
+            Row(1, "prod", "", 20),
+        };
+        var allowed = new HashSet<int> { 10 };
+
+        var result = TagsEndpointMappings.BuildTagRows(rows, allowed);
+
+        Assert.Equal(new[] { 10 }, Assert.Single(result).InstanceIds);
+    }
+
+    [Fact]
+    public void BuildTagRows_TagWithNoInstancesLeftAfterScoping_IsDropped()
+    {
+        var rows = new List<Dictionary<string, object?>>
+        {
+            Row(1, "prod", "", 10),
+            Row(2, "dev", "", 20),
+        };
+        var allowed = new HashSet<int> { 10 };
+
+        var result = TagsEndpointMappings.BuildTagRows(rows, allowed);
+
+        var tag = Assert.Single(result);
+        Assert.Equal(1, tag.TagId);
+    }
+
+    [Fact]
+    public void BuildTagRows_OrdersSystemTagsAfterUserTags_ThenAlphabetically()
+    {
+        var rows = new List<Dictionary<string, object?>>
+        {
+            Row(1, "{Version}", "2019", 10),
+            Row(2, "web", "", 10),
+            Row(3, "app", "", 10),
+        };
+
+        var result = TagsEndpointMappings.BuildTagRows(rows, allowedInstanceIds: null);
+
+        Assert.Equal(new[] { "app", "web", "{Version}" }, result.Select(t => t.TagName));
+    }
+}

--- a/backend.tests/UserScopeTests.cs
+++ b/backend.tests/UserScopeTests.cs
@@ -73,8 +73,8 @@ public sealed class UserScopeTests
         Assert.Contains("i.InstanceID IN", predicate);
         Assert.Contains("@scope_tag_0", predicate);
         Assert.Contains("@scope_tag_1", predicate);
-        Assert.Contains("dbo.InstanceTag", predicate);
-        Assert.Contains("dbo.Tag", predicate);
+        Assert.Contains("dbo.InstanceIDsTags", predicate);
+        Assert.Contains("dbo.Tags", predicate);
         // Values must not be inlined into the SQL.
         Assert.DoesNotContain("prod", predicate);
         Assert.DoesNotContain("eu-west", predicate);

--- a/backend/Auth/UserScope.cs
+++ b/backend/Auth/UserScope.cs
@@ -63,7 +63,7 @@ public sealed class UserScope
     /// caller must pass the resulting parameters from
     /// <see cref="AppendParameters"/> to the command.
     ///
-    /// The predicate joins against <c>dbo.InstanceTag</c> / <c>dbo.Tag</c>
+    /// The predicate joins against <c>dbo.InstanceIDsTags</c> / <c>dbo.Tags</c>
     /// (standard DBA Dash tag schema) for tag scope. Group scope is not yet
     /// enforced at the SQL layer — the values are kept on the JWT so admins
     /// can opt-in once the consuming deployment standardises on a group
@@ -82,7 +82,7 @@ public sealed class UserScope
             .ToArray();
 
         var inList = string.Join(", ", paramNames);
-        return $"{instanceIdColumn} IN (SELECT it.InstanceID FROM dbo.InstanceTag it JOIN dbo.Tag t ON it.TagID = t.TagID WHERE t.TagName IN ({inList}))";
+        return $"{instanceIdColumn} IN (SELECT it.InstanceID FROM dbo.InstanceIDsTags it JOIN dbo.Tags t ON it.TagID = t.TagID WHERE t.TagName IN ({inList}))";
     }
 
     /// <summary>
@@ -140,7 +140,7 @@ public sealed class UserScope
         }
 
         var paramNames = string.Join(", ", AllowedTags.Select((_, index) => "@scope_tag_" + index));
-        var query = $"SELECT DISTINCT it.InstanceID FROM dbo.InstanceTag it JOIN dbo.Tag t ON it.TagID = t.TagID WHERE t.TagName IN ({paramNames})";
+        var query = $"SELECT DISTINCT it.InstanceID FROM dbo.InstanceIDsTags it JOIN dbo.Tags t ON it.TagID = t.TagID WHERE t.TagName IN ({paramNames})";
 
         var rows = await sql.QueryAsync(query, cancellationToken, ParameterTuples().ToArray());
         var ids = new HashSet<int>();
@@ -173,7 +173,7 @@ public sealed class UserScope
         parameters.AddRange(ParameterTuples());
 
         var paramNames = string.Join(", ", AllowedTags.Select((_, index) => "@scope_tag_" + index));
-        var query = $"SELECT TOP 1 1 FROM dbo.InstanceTag it JOIN dbo.Tag t ON it.TagID = t.TagID WHERE it.InstanceID = @instanceId AND t.TagName IN ({paramNames})";
+        var query = $"SELECT TOP 1 1 FROM dbo.InstanceIDsTags it JOIN dbo.Tags t ON it.TagID = t.TagID WHERE it.InstanceID = @instanceId AND t.TagName IN ({paramNames})";
 
         var rows = await sql.QueryAsync(query, cancellationToken, parameters.ToArray());
         return rows.Count > 0;

--- a/backend/Endpoints/TagsEndpointMappings.cs
+++ b/backend/Endpoints/TagsEndpointMappings.cs
@@ -1,0 +1,235 @@
+using System.Security.Claims;
+using DBADashWebView.Auth;
+using DBADashWebView.Data;
+
+namespace DBADashWebView.Endpoints;
+
+public sealed record TagRow(int TagId, string TagName, string? TagValue, bool IsSystem, int[] InstanceIds);
+
+public sealed record CreateTagRequest(string TagName, string? TagValue, int[] InstanceIds);
+
+/// <summary>
+/// Surfaces DBA Dash's real tag schema (<c>dbo.Tags</c> / <c>dbo.InstanceIDsTags</c>) to
+/// the Groups &amp; Tags UI. System tags (populated by <c>dbo.SystemTags_Upd</c>, named
+/// like <c>{Version}</c>) are read-only here — only plain user tags can be created,
+/// applied, or removed.
+/// </summary>
+public static class TagsEndpointMappings
+{
+    public static IEndpointRouteBuilder MapTagsEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/api/tags", async (ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var allowedIds = await user.AllowedInstanceIdsAsync(sql, cancellationToken);
+                var rows = await sql.QueryAsync(
+                    """
+                    SELECT T.TagID, T.TagName, T.TagValue, IT.InstanceID
+                    FROM dbo.Tags T
+                    JOIN dbo.InstanceIDsTags IT ON T.TagID = IT.TagID
+                    JOIN dbo.Instances I ON IT.InstanceID = I.InstanceID
+                    WHERE I.IsActive = 1
+                    ORDER BY T.TagName, T.TagValue
+                    """,
+                    cancellationToken);
+
+                return Results.Ok(BuildTagRows(rows, allowedIds));
+            }
+            catch (Exception ex)
+            {
+                return Results.Ok(new { error = ex.Message, data = Array.Empty<object>() });
+            }
+        }).RequireAuthorization();
+
+        endpoints.MapPost("/api/tags", async (
+            CreateTagRequest request,
+            SqlDataService sql,
+            CancellationToken cancellationToken) =>
+        {
+            var tagName = request.TagName.Trim();
+            if (string.IsNullOrWhiteSpace(tagName))
+            {
+                return Results.Problem(title: "Tag name is required", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (tagName.StartsWith('{'))
+            {
+                return Results.Problem(title: "System tag names cannot be created manually", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            if (request.InstanceIds is null || request.InstanceIds.Length == 0)
+            {
+                return Results.Problem(title: "At least one instance is required", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var tagValue = request.TagValue?.Trim() ?? string.Empty;
+
+            var existing = await sql.QueryAsync(
+                "SELECT TagID FROM dbo.Tags WHERE TagName = @tagName AND TagValue = @tagValue",
+                cancellationToken,
+                ("@tagName", tagName), ("@tagValue", tagValue));
+
+            int tagId;
+            if (existing.Count > 0)
+            {
+                tagId = Convert.ToInt32(existing[0]["TagID"]);
+            }
+            else
+            {
+                var inserted = await sql.QueryAsync(
+                    "INSERT INTO dbo.Tags (TagName, TagValue) OUTPUT INSERTED.TagID VALUES (@tagName, @tagValue)",
+                    cancellationToken,
+                    ("@tagName", tagName), ("@tagValue", tagValue));
+                tagId = Convert.ToInt32(inserted[0]["TagID"]);
+            }
+
+            var instanceIds = request.InstanceIds.Distinct().ToArray();
+            foreach (var instanceId in instanceIds)
+            {
+                await sql.QueryAsync(
+                    """
+                    IF NOT EXISTS (SELECT 1 FROM dbo.InstanceIDsTags WHERE InstanceID = @instanceId AND TagID = @tagId)
+                    INSERT INTO dbo.InstanceIDsTags (InstanceID, TagID) VALUES (@instanceId, @tagId)
+                    """,
+                    cancellationToken,
+                    ("@instanceId", instanceId), ("@tagId", tagId));
+            }
+
+            return Results.Ok(new TagRow(tagId, tagName, tagValue, false, instanceIds));
+        }).RequireAuthorization(AppPolicies.AdminOnly);
+
+        endpoints.MapPost("/api/tags/{tagId:int}/instances/{instanceId:int}", async (
+            int tagId,
+            int instanceId,
+            SqlDataService sql,
+            CancellationToken cancellationToken) =>
+        {
+            var guard = await EnsureUserTagAsync(sql, tagId, cancellationToken);
+            if (guard is not null) return guard;
+
+            await sql.QueryAsync(
+                """
+                IF NOT EXISTS (SELECT 1 FROM dbo.InstanceIDsTags WHERE InstanceID = @instanceId AND TagID = @tagId)
+                INSERT INTO dbo.InstanceIDsTags (InstanceID, TagID) VALUES (@instanceId, @tagId)
+                """,
+                cancellationToken,
+                ("@instanceId", instanceId), ("@tagId", tagId));
+
+            return Results.Ok(new { success = true });
+        }).RequireAuthorization(AppPolicies.AdminOnly);
+
+        endpoints.MapDelete("/api/tags/{tagId:int}/instances/{instanceId:int}", async (
+            int tagId,
+            int instanceId,
+            SqlDataService sql,
+            CancellationToken cancellationToken) =>
+        {
+            var guard = await EnsureUserTagAsync(sql, tagId, cancellationToken);
+            if (guard is not null) return guard;
+
+            await sql.QueryAsync(
+                "DELETE FROM dbo.InstanceIDsTags WHERE TagID = @tagId AND InstanceID = @instanceId",
+                cancellationToken,
+                ("@tagId", tagId), ("@instanceId", instanceId));
+
+            await DeleteOrphanTagAsync(sql, tagId, cancellationToken);
+
+            return Results.Ok(new { success = true });
+        }).RequireAuthorization(AppPolicies.AdminOnly);
+
+        endpoints.MapDelete("/api/tags/{tagId:int}", async (
+            int tagId,
+            SqlDataService sql,
+            CancellationToken cancellationToken) =>
+        {
+            var guard = await EnsureUserTagAsync(sql, tagId, cancellationToken);
+            if (guard is not null) return guard;
+
+            await sql.QueryAsync("DELETE FROM dbo.InstanceIDsTags WHERE TagID = @tagId", cancellationToken, ("@tagId", tagId));
+            await sql.QueryAsync("DELETE FROM dbo.InstanceTags WHERE TagID = @tagId", cancellationToken, ("@tagId", tagId));
+            await sql.QueryAsync("DELETE FROM dbo.Tags WHERE TagID = @tagId", cancellationToken, ("@tagId", tagId));
+
+            return Results.Ok(new { success = true });
+        }).RequireAuthorization(AppPolicies.AdminOnly);
+
+        return endpoints;
+    }
+
+    /// <summary>
+    /// Groups flat (TagID, TagName, TagValue, InstanceID) rows into one
+    /// <see cref="TagRow"/> per tag, applying the caller's instance scope and
+    /// dropping tags that have no instances left once scoped. Kept separate
+    /// from the SQL so it can be unit tested with synthetic rows.
+    /// </summary>
+    internal static List<TagRow> BuildTagRows(
+        List<Dictionary<string, object?>> rows,
+        HashSet<int>? allowedInstanceIds)
+    {
+        var tags = new Dictionary<int, (string TagName, string? TagValue, List<int> InstanceIds)>();
+        foreach (var row in rows)
+        {
+            var instanceId = Convert.ToInt32(row["InstanceID"]);
+            if (allowedInstanceIds is not null && !allowedInstanceIds.Contains(instanceId))
+            {
+                continue;
+            }
+
+            var tagId = Convert.ToInt32(row["TagID"]);
+            if (!tags.TryGetValue(tagId, out var entry))
+            {
+                entry = (row["TagName"]?.ToString() ?? string.Empty, row["TagValue"]?.ToString(), new List<int>());
+                tags[tagId] = entry;
+            }
+
+            entry.InstanceIds.Add(instanceId);
+        }
+
+        return tags
+            .Where(kvp => kvp.Value.InstanceIds.Count > 0)
+            .Select(kvp => new TagRow(
+                kvp.Key,
+                kvp.Value.TagName,
+                kvp.Value.TagValue,
+                kvp.Value.TagName.StartsWith('{'),
+                kvp.Value.InstanceIds.ToArray()))
+            .OrderBy(t => t.IsSystem)
+            .ThenBy(t => t.TagName, StringComparer.OrdinalIgnoreCase)
+            .ThenBy(t => t.TagValue, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static async Task<IResult?> EnsureUserTagAsync(SqlDataService sql, int tagId, CancellationToken cancellationToken)
+    {
+        var rows = await sql.QueryAsync("SELECT TagName FROM dbo.Tags WHERE TagID = @tagId", cancellationToken, ("@tagId", tagId));
+        if (rows.Count == 0)
+        {
+            return Results.Problem(title: "Tag not found", statusCode: StatusCodes.Status404NotFound);
+        }
+
+        var tagName = rows[0]["TagName"]?.ToString() ?? string.Empty;
+        if (tagName.StartsWith('{'))
+        {
+            return Results.Problem(title: "System tags cannot be modified", statusCode: StatusCodes.Status400BadRequest);
+        }
+
+        return null;
+    }
+
+    private static async Task DeleteOrphanTagAsync(SqlDataService sql, int tagId, CancellationToken cancellationToken)
+    {
+        var stillUsed = await sql.QueryAsync(
+            """
+            SELECT 1 FROM dbo.InstanceIDsTags WHERE TagID = @tagId
+            UNION ALL
+            SELECT 1 FROM dbo.InstanceTags WHERE TagID = @tagId
+            """,
+            cancellationToken,
+            ("@tagId", tagId));
+
+        if (stillUsed.Count == 0)
+        {
+            await sql.QueryAsync("DELETE FROM dbo.Tags WHERE TagID = @tagId", cancellationToken, ("@tagId", tagId));
+        }
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -97,6 +97,7 @@ app.MapPerformanceEndpoints();
 app.MapMonitoringEndpoints();
 app.MapEstateEndpoints();
 app.MapReportEndpoints();
+app.MapTagsEndpoints();
 
 app.MapFallbackToFile("index.html");
 

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -10,6 +10,7 @@ import type {
   ApiRow,
   AuthStatusResponse,
   CreateLocalUserRequest,
+  CreateTagRequest,
   DbSpaceRow,
   EstateBackupRow,
   EstateDriveRow,
@@ -45,6 +46,7 @@ import type {
   RunningQueryRow,
   SchemaChangeRow,
   SlowQueryRow,
+  TagRow,
   TempDbFileRow,
   ThresholdMap,
   TreeInstanceNode,
@@ -224,4 +226,13 @@ export const api = {
     request<LocalUser>('/api/settings/users', { method: 'POST', body: JSON.stringify(payload) }),
   updateLocalUser: (id: string, payload: UpdateLocalUserRequest) =>
     request<LocalUser>(`/api/settings/users/${id}`, { method: 'PUT', body: JSON.stringify(payload) }),
+  tags: () => request<TagRow[]>('/api/tags'),
+  createTag: (payload: CreateTagRequest) =>
+    request<TagRow>('/api/tags', { method: 'POST', body: JSON.stringify(payload) }),
+  deleteTag: (tagId: number) =>
+    request<{ success: boolean }>(`/api/tags/${tagId}`, { method: 'DELETE' }),
+  attachTag: (tagId: number, instanceId: number) =>
+    request<{ success: boolean }>(`/api/tags/${tagId}/instances/${instanceId}`, { method: 'POST' }),
+  detachTag: (tagId: number, instanceId: number) =>
+    request<{ success: boolean }>(`/api/tags/${tagId}/instances/${instanceId}`, { method: 'DELETE' }),
 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -733,6 +733,20 @@ export interface TempDbFileRow extends ApiRow {
   usedKb?: number | null;
 }
 
+export interface TagRow extends ApiRow {
+  tagId: number;
+  tagName: string;
+  tagValue?: string | null;
+  isSystem: boolean;
+  instanceIds: number[];
+}
+
+export interface CreateTagRequest {
+  tagName: string;
+  tagValue?: string;
+  instanceIds: number[];
+}
+
 export interface DbSpaceRow extends ApiRow {
   databaseName?: string | null;
   fileName?: string | null;

--- a/frontend/src/pages/ConfigGroupsPage.tsx
+++ b/frontend/src/pages/ConfigGroupsPage.tsx
@@ -1,27 +1,123 @@
-import { useState, useEffect } from 'react';
-import { Plus, Trash2, X, Tag } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { Plus, Trash2, X, Tag, ChevronDown, ChevronRight, Loader2, Lock } from 'lucide-react';
+import { api } from '../api/api';
+import type { InstanceListRow, TagRow } from '../api/types';
 
 interface Group { id: number; name: string; description: string; members: string[] }
-interface TagItem { id: number; name: string; appliedTo: number }
 
 function loadGroups(): Group[] {
   try { return JSON.parse(localStorage.getItem('config_groups') || '[]'); } catch { return []; }
 }
 function saveGroups(g: Group[]) { localStorage.setItem('config_groups', JSON.stringify(g)); }
-function loadTags(): TagItem[] {
-  try { return JSON.parse(localStorage.getItem('config_tags') || '[]'); } catch { return []; }
+
+function instanceLabel(instance: InstanceListRow | undefined, instanceId: number): string {
+  return instance?.InstanceDisplayName || instance?.Instance || `Instance #${instanceId}`;
 }
-function saveTags(t: TagItem[]) { localStorage.setItem('config_tags', JSON.stringify(t)); }
+
+function tagLabel(tag: TagRow): string {
+  const name = tag.isSystem ? tag.tagName.replace(/^\{|\}$/g, '') : tag.tagName;
+  return tag.tagValue ? `${name}: ${tag.tagValue}` : name;
+}
 
 export default function ConfigGroupsPage() {
   const [groups, setGroups] = useState<Group[]>(loadGroups);
-  const [tags, setTags] = useState<TagItem[]>(loadTags);
   const [showAddGroup, setShowAddGroup] = useState(false);
   const [newGroup, setNewGroup] = useState({ name: '', description: '' });
-  const [newTag, setNewTag] = useState('');
 
   useEffect(() => { saveGroups(groups); }, [groups]);
-  useEffect(() => { saveTags(tags); }, [tags]);
+
+  const [tags, setTags] = useState<TagRow[]>([]);
+  const [instances, setInstances] = useState<InstanceListRow[]>([]);
+  const [tagsLoading, setTagsLoading] = useState(true);
+  const [expandedTagId, setExpandedTagId] = useState<number | null>(null);
+  const [showAddTag, setShowAddTag] = useState(false);
+  const [newTag, setNewTag] = useState({ name: '', value: '', instanceIds: new Set<number>() });
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => { loadTagData(); }, []);
+
+  async function loadTagData() {
+    setTagsLoading(true);
+    try {
+      const [tagList, instanceList] = await Promise.all([
+        api.tags().catch(() => []),
+        api.instances().catch(() => []),
+      ]);
+      // The backend falls back to `{ error, data: [] }` (HTTP 200) instead of an
+      // array when a SQL call fails, so guard against a non-array response here
+      // rather than assuming the typed shape always holds at runtime.
+      setTags(Array.isArray(tagList) ? tagList : []);
+      setInstances(Array.isArray(instanceList) ? instanceList : []);
+    } finally {
+      setTagsLoading(false);
+    }
+  }
+
+  const instanceById = useMemo(() => {
+    const map = new Map<number, InstanceListRow>();
+    for (const instance of instances) map.set(instance.InstanceID, instance);
+    return map;
+  }, [instances]);
+
+  const systemTags = useMemo(() => tags.filter(t => t.isSystem), [tags]);
+  const customTags = useMemo(() => tags.filter(t => !t.isSystem), [tags]);
+
+  async function handleCreateTag() {
+    const tagName = newTag.name.trim();
+    if (!tagName || newTag.instanceIds.size === 0) {
+      setError('Tag name and at least one instance are required.');
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      await api.createTag({
+        tagName,
+        tagValue: newTag.value.trim() || undefined,
+        instanceIds: Array.from(newTag.instanceIds),
+      });
+      setNewTag({ name: '', value: '', instanceIds: new Set() });
+      setShowAddTag(false);
+      await loadTagData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to create tag.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDeleteTag(tagId: number) {
+    setSaving(true);
+    try {
+      await api.deleteTag(tagId);
+      await loadTagData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to delete tag.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDetachInstance(tagId: number, instanceId: number) {
+    setSaving(true);
+    try {
+      await api.detachTag(tagId, instanceId);
+      await loadTagData();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to remove instance from tag.');
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function toggleNewTagInstance(instanceId: number) {
+    setNewTag(prev => {
+      const next = new Set(prev.instanceIds);
+      if (next.has(instanceId)) next.delete(instanceId); else next.add(instanceId);
+      return { ...prev, instanceIds: next };
+    });
+  }
 
   return (
     <div className="space-y-6">
@@ -90,26 +186,136 @@ export default function ConfigGroupsPage() {
       <div className="glass rounded-xl p-6 gradient-border">
         <div className="flex items-center justify-between mb-4">
           <h3 className="text-lg font-semibold text-white flex items-center gap-2"><Tag className="w-5 h-5 text-purple-400" /> Tags</h3>
-        </div>
-        <div className="flex gap-2 mb-4">
-          <input placeholder="New tag name" value={newTag} onChange={e => setNewTag(e.target.value)}
-            onKeyDown={e => { if (e.key === 'Enter' && newTag) { setTags(prev => [...prev, { id: Date.now(), name: newTag, appliedTo: 0 }]); setNewTag(''); }}}
-            className="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white text-sm flex-1" />
-          <button onClick={() => { if (newTag) { setTags(prev => [...prev, { id: Date.now(), name: newTag, appliedTo: 0 }]); setNewTag(''); }}}
-            className="px-3 py-2 bg-blue-500/20 text-blue-400 rounded-lg text-sm hover:bg-blue-500/30 transition-colors">
-            Add
+          <button onClick={() => setShowAddTag(true)} className="flex items-center gap-2 px-3 py-1.5 bg-blue-500/20 text-blue-400 rounded-lg text-sm hover:bg-blue-500/30 transition-colors">
+            <Plus className="w-4 h-4" /> Create Tag
           </button>
         </div>
-        <div className="flex flex-wrap gap-2">
-          {tags.map(t => (
-            <span key={t.id} className="flex items-center gap-1.5 px-3 py-1.5 bg-purple-500/10 text-purple-400 rounded-full text-sm">
-              {t.name}
-              <button onClick={() => setTags(prev => prev.filter(x => x.id !== t.id))} className="hover:text-red-400"><X className="w-3 h-3" /></button>
-            </span>
-          ))}
-          {tags.length === 0 && <span className="text-gray-500 text-sm">No tags defined.</span>}
-        </div>
+        <p className="text-xs text-gray-500 mb-4">
+          Sourced from DBA Dash's tag tables (<code>dbo.Tags</code> / <code>dbo.InstanceIDsTags</code>) — shared across all users. System tags are collected automatically and can't be edited here.
+        </p>
+
+        {error && (
+          <div className="mb-4 rounded-lg bg-red-500/10 px-4 py-2 text-sm text-red-300">{error}</div>
+        )}
+
+        {tagsLoading ? (
+          <div className="flex items-center gap-2 text-gray-400 py-4">
+            <Loader2 className="w-4 h-4 animate-spin" /> Loading tags...
+          </div>
+        ) : (
+          <div className="space-y-6">
+            <div>
+              <h4 className="text-sm font-semibold text-gray-300 mb-2">Custom Tags</h4>
+              <div className="space-y-2">
+                {customTags.map(tag => (
+                  <div key={tag.tagId} className="rounded-lg border border-white/5 bg-white/[0.02]">
+                    <div className="flex items-center justify-between px-3 py-2">
+                      <button
+                        onClick={() => setExpandedTagId(prev => (prev === tag.tagId ? null : tag.tagId))}
+                        className="flex items-center gap-2 text-sm text-white hover:text-purple-300 transition-colors"
+                      >
+                        {expandedTagId === tag.tagId ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+                        <span className="px-2.5 py-1 bg-purple-500/10 text-purple-400 rounded-full">{tagLabel(tag)}</span>
+                        <span className="text-gray-500 text-xs">{tag.instanceIds.length} instance{tag.instanceIds.length === 1 ? '' : 's'}</span>
+                      </button>
+                      <button
+                        onClick={() => handleDeleteTag(tag.tagId)}
+                        disabled={saving}
+                        className="p-1.5 rounded hover:bg-red-500/10 text-gray-400 hover:text-red-400 disabled:opacity-50"
+                        title="Delete tag"
+                      >
+                        <Trash2 className="w-3.5 h-3.5" />
+                      </button>
+                    </div>
+                    {expandedTagId === tag.tagId && (
+                      <div className="px-3 pb-3 flex flex-wrap gap-2">
+                        {tag.instanceIds.map(instanceId => (
+                          <span key={instanceId} className="flex items-center gap-1.5 px-2.5 py-1 bg-white/5 text-gray-300 rounded-full text-xs">
+                            {instanceLabel(instanceById.get(instanceId), instanceId)}
+                            <button
+                              onClick={() => handleDetachInstance(tag.tagId, instanceId)}
+                              disabled={saving}
+                              className="hover:text-red-400 disabled:opacity-50"
+                              title="Remove instance from tag"
+                            >
+                              <X className="w-3 h-3" />
+                            </button>
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ))}
+                {customTags.length === 0 && <p className="text-gray-500 text-sm py-2">No custom tags defined yet.</p>}
+              </div>
+            </div>
+
+            <div>
+              <h4 className="text-sm font-semibold text-gray-300 mb-2 flex items-center gap-1.5">
+                <Lock className="w-3.5 h-3.5 text-gray-500" /> System Tags
+              </h4>
+              <div className="flex flex-wrap gap-2">
+                {systemTags.map(tag => (
+                  <span key={tag.tagId} className="flex items-center gap-1.5 px-3 py-1.5 bg-white/5 text-gray-400 rounded-full text-sm" title={`${tag.instanceIds.length} instance(s)`}>
+                    {tagLabel(tag)}
+                    <span className="text-gray-600 text-xs">({tag.instanceIds.length})</span>
+                  </span>
+                ))}
+                {systemTags.length === 0 && <span className="text-gray-500 text-sm">No system tags collected yet.</span>}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
+
+      {showAddTag && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setShowAddTag(false)}>
+          <div className="glass rounded-xl p-6 w-[28rem] gradient-border max-h-[80vh] overflow-y-auto" onClick={e => e.stopPropagation()}>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-white">Create Tag</h3>
+              <button onClick={() => setShowAddTag(false)} className="text-gray-400 hover:text-white"><X className="w-5 h-5" /></button>
+            </div>
+            <div className="space-y-3">
+              <input
+                placeholder="Tag name"
+                value={newTag.name}
+                onChange={e => setNewTag(p => ({ ...p, name: e.target.value }))}
+                className="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white text-sm"
+              />
+              <input
+                placeholder="Tag value (optional)"
+                value={newTag.value}
+                onChange={e => setNewTag(p => ({ ...p, value: e.target.value }))}
+                className="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white text-sm"
+              />
+              <div>
+                <p className="text-xs uppercase tracking-wide text-gray-400 mb-1.5">Apply to instances</p>
+                <div className="max-h-48 overflow-y-auto rounded-lg border border-slate-700 divide-y divide-slate-800">
+                  {instances.map(instance => (
+                    <label key={instance.InstanceID} className="flex items-center gap-2 px-3 py-2 text-sm text-gray-300 hover:bg-white/5 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={newTag.instanceIds.has(instance.InstanceID)}
+                        onChange={() => toggleNewTagInstance(instance.InstanceID)}
+                        className="h-4 w-4 rounded border-white/20 bg-white/10"
+                      />
+                      {instanceLabel(instance, instance.InstanceID)}
+                    </label>
+                  ))}
+                  {instances.length === 0 && <p className="px-3 py-2 text-sm text-gray-500">No instances available.</p>}
+                </div>
+              </div>
+              <button
+                onClick={handleCreateTag}
+                disabled={saving}
+                className="w-full py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+              >
+                {saving ? 'Creating...' : 'Create'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Replace the localStorage-backed tag list with data read from DBA Dash's own dbo.Tags / dbo.InstanceIDsTags tables, so tagging is shared across users instead of per-browser.

- New GET/POST/DELETE /api/tags endpoints for listing, creating, and removing tags, with system tags (e.g. {Version}, {Edition}) exposed read-only and user tags editable by admins.
- ConfigGroupsPage now fetches tags from the API and splits them into System Tags and Custom Tags, with an instance picker for new tags.
- Fix UserScope's per-user tag scoping, which was querying dbo.InstanceTag/dbo.Tag - tables that don't exist in DBA Dash's actual schema (dbo.InstanceIDsTags/dbo.Tags) - so scoped users were never actually being restricted.
- Add unit tests for the new tag-row grouping logic and update the UserScope tests for the corrected table names.

## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: ___

## Checklist

- [X] `npm run build` passes (frontend)
- [X] `dotnet build` passes (backend)
- [X] Tested in browser (dark theme)
- [X] No new TypeScript errors
- [X] SQL queries use parameterized `@param` (no string concat)

## Screenshots

<!-- If applicable, add screenshots of the change -->
<img width="2209" height="328" alt="image" src="https://github.com/user-attachments/assets/f044f475-c6be-4ed0-811a-ae488509efc1" />
