### PR TITLE
Add alert Acknowledge/Close/Notes lifecycle to Alerts page (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,6 +466,34 @@ ALTER ROLE db_datareader ADD MEMBER [dbadashweb];
 GRANT EXECUTE ON SCHEMA::dbo TO [dbadashweb];
 ```
 
+### Write Capabilities (optional)
+
+Everything above is read-only. Features that write back to DBADashDB are opt-in and
+stay disabled unless you enable them *and* grant the matching EXECUTE permissions —
+otherwise the UI would show buttons that can only fail.
+
+| Capability | Setting | Additional grants |
+| --- | --- | --- |
+| Alert acknowledge / close / notes | `WriteCapabilities:AlertLifecycle` | `Alert.ActiveAlertsAck_Upd`, `Alert.ClosedAlerts_Add`, `Alert.Alerts_Notes_Upd` |
+
+```json
+{
+  "WriteCapabilities": {
+    "AlertLifecycle": true
+  }
+}
+```
+
+```sql
+USE DBADashDB;
+GRANT EXECUTE ON OBJECT::Alert.ActiveAlertsAck_Upd TO [dbadashweb];
+GRANT EXECUTE ON OBJECT::Alert.ClosedAlerts_Add    TO [dbadashweb];
+GRANT EXECUTE ON OBJECT::Alert.Alerts_Notes_Upd    TO [dbadashweb];
+```
+
+The alert lifecycle schema (`Alert.*`) requires DBA Dash 3.17.0 or later. On older
+repositories the alert panel reports that it is unsupported instead of failing.
+
 ### Active Directory Authentication
 
 Configure via **Settings -> Users -> Active Directory**, or directly edit `config/ad-config.json`:

--- a/README.md
+++ b/README.md
@@ -464,6 +464,11 @@ CREATE LOGIN [dbadashweb] WITH PASSWORD = 'YourSecurePassword';
 CREATE USER [dbadashweb] FOR LOGIN [dbadashweb];
 ALTER ROLE db_datareader ADD MEMBER [dbadashweb];
 GRANT EXECUTE ON SCHEMA::dbo TO [dbadashweb];
+
+-- Required for the DBA Dash Alerts panel (DBA Dash 3.17.0 or later)
+GRANT EXECUTE ON OBJECT::Alert.ActiveAlerts_Get TO [dbadashweb];
+GRANT EXECUTE ON OBJECT::Alert.ClosedAlerts_Get TO [dbadashweb];
+GRANT REFERENCES ON TYPE::dbo.IDs TO [dbadashweb];
 ```
 
 ### Write Capabilities (optional)
@@ -489,6 +494,7 @@ USE DBADashDB;
 GRANT EXECUTE ON OBJECT::Alert.ActiveAlertsAck_Upd TO [dbadashweb];
 GRANT EXECUTE ON OBJECT::Alert.ClosedAlerts_Add    TO [dbadashweb];
 GRANT EXECUTE ON OBJECT::Alert.Alerts_Notes_Upd    TO [dbadashweb];
+GRANT REFERENCES ON TYPE::dbo.BigIDs               TO [dbadashweb];
 ```
 
 The alert lifecycle schema (`Alert.*`) requires DBA Dash 3.17.0 or later. On older

--- a/backend.tests/AlertsEndpointMappingsTests.cs
+++ b/backend.tests/AlertsEndpointMappingsTests.cs
@@ -1,0 +1,80 @@
+using System.Data;
+using DBADashWebView.Endpoints;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient.Server;
+using Xunit;
+
+namespace DBADashWebView.Tests;
+
+public sealed class AlertsEndpointMappingsTests
+{
+    [Theory]
+    [InlineData(208, "Invalid object name 'Alert.ActiveAlerts_Get'.", true)]
+    [InlineData(2812, "Could not find stored procedure 'Alert.ClosedAlerts_Add'.", true)]
+    [InlineData(208, "Invalid object name 'dbo.SomeOtherTable'.", false)]
+    [InlineData(547, "The INSERT statement conflicted with Alert.FK_ActiveAlerts_Rules", false)]
+    public void IsMissingAlertSchema_DetectsMissingAlertObjectsOnly(int errorNumber, string message, bool expected)
+    {
+        Assert.Equal(expected, AlertsEndpointMappings.IsMissingAlertSchema(errorNumber, message));
+    }
+
+    [Fact]
+    public void BuildIntIdsParameter_UsesDboIDsType()
+    {
+        var parameter = AlertsEndpointMappings.BuildIntIdsParameter("@InstanceIDs", new HashSet<int> { 1, 2, 3 });
+
+        Assert.Equal(SqlDbType.Structured, parameter.SqlDbType);
+        Assert.Equal("dbo.IDs", parameter.TypeName);
+        Assert.Equal("@InstanceIDs", parameter.ParameterName);
+    }
+
+    [Fact]
+    public void BuildIntIdsParameter_RoundTripsValues()
+    {
+        var parameter = AlertsEndpointMappings.BuildIntIdsParameter("@InstanceIDs", new HashSet<int> { 5, 9 });
+
+        var records = Assert.IsAssignableFrom<IEnumerable<SqlDataRecord>>(parameter.Value).ToList();
+        var values = records.Select(r => r.GetInt32(0)).OrderBy(v => v).ToArray();
+
+        Assert.Equal(new[] { 5, 9 }, values);
+    }
+
+    [Fact]
+    public void BuildIntIdsParameter_NullOrEmptySet_SendsNullValue()
+    {
+        // SqlClient throws ("There are no records in the SqlDataRecord enumeration...")
+        // if a structured parameter is given an empty IEnumerable<SqlDataRecord> instead
+        // of null for a zero-row table-valued parameter.
+        var parameter = AlertsEndpointMappings.BuildIntIdsParameter("@InstanceIDs", null);
+
+        Assert.Null(parameter.Value);
+    }
+
+    [Fact]
+    public void BuildBigIntIdsParameter_UsesDboBigIDsType()
+    {
+        var parameter = AlertsEndpointMappings.BuildBigIntIdsParameter("@AlertIDs", new long[] { 100L });
+
+        Assert.Equal(SqlDbType.Structured, parameter.SqlDbType);
+        Assert.Equal("dbo.BigIDs", parameter.TypeName);
+    }
+
+    [Fact]
+    public void BuildBigIntIdsParameter_EmptyInput_SendsNullValue()
+    {
+        var parameter = AlertsEndpointMappings.BuildBigIntIdsParameter("@AlertIDs", Array.Empty<long>());
+
+        Assert.Null(parameter.Value);
+    }
+
+    [Fact]
+    public void BuildBigIntIdsParameter_DedupesInput()
+    {
+        var parameter = AlertsEndpointMappings.BuildBigIntIdsParameter("@AlertIDs", new long[] { 7L, 7L, 8L });
+
+        var records = Assert.IsAssignableFrom<IEnumerable<SqlDataRecord>>(parameter.Value).ToList();
+        var values = records.Select(r => r.GetInt64(0)).OrderBy(v => v).ToArray();
+
+        Assert.Equal(new[] { 7L, 8L }, values);
+    }
+}

--- a/backend.tests/AlertsEndpointScopeTests.cs
+++ b/backend.tests/AlertsEndpointScopeTests.cs
@@ -1,0 +1,179 @@
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using DBADashWebView.Auth;
+using DBADashWebView.Data;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace DBADashWebView.Tests;
+
+/// <summary>
+/// End-to-end guard for the alert scope short-circuit.
+///
+/// Alert.ActiveAlerts_Get and Alert.ClosedAlerts_Get treat an empty table-valued
+/// parameter as "all instances", so a tag-restricted user matching no instance
+/// must never reach the procedure. These tests drive the real endpoints with a
+/// scoped JWT and a SqlDataService whose scope lookup returns no rows; if the
+/// short-circuit is removed, the handler opens a connection and the request fails
+/// instead of returning an empty list.
+/// </summary>
+public sealed class AlertsEndpointScopeTests : IClassFixture<AlertsWebApplicationFactory>
+{
+    private readonly AlertsWebApplicationFactory _factory;
+
+    public AlertsEndpointScopeTests(AlertsWebApplicationFactory factory) => _factory = factory;
+
+    [Theory]
+    [InlineData("/api/alerts/active")]
+    [InlineData("/api/alerts/closed")]
+    public async Task RestrictedScopeMatchingNoInstance_ReturnsEmpty_WithoutQueryingAlerts(string path)
+    {
+        _factory.Sql.Reset();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", _factory.TokenFor(AppRoles.Viewer, ["no-such-tag"]));
+
+        var response = await client.GetAsync(path);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        using var payload = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.True(payload.RootElement.GetProperty("supported").GetBoolean());
+        Assert.Empty(payload.RootElement.GetProperty("data").EnumerateArray());
+
+        // Exactly one query — the scope lookup. Reaching the stored procedure would
+        // mean opening a real connection, which is the leak this guards against.
+        Assert.Equal(1, _factory.Sql.QueryCount);
+        Assert.Contains("InstanceID", _factory.Sql.LastSql, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("/api/alerts/active")]
+    [InlineData("/api/alerts/closed")]
+    public async Task UnauthenticatedRequest_IsRejected(string path)
+    {
+        var response = await _factory.CreateClient().GetAsync(path);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}
+
+/// <summary>
+/// The alert write endpoints call stored procedures that a db_datareader
+/// deployment cannot execute, so they stay closed until an operator opts in.
+/// </summary>
+public sealed class AlertsEndpointWriteCapabilityTests : IClassFixture<AlertsWebApplicationFactory>
+{
+    private readonly AlertsWebApplicationFactory _factory;
+
+    public AlertsEndpointWriteCapabilityTests(AlertsWebApplicationFactory factory) => _factory = factory;
+
+    public static TheoryData<HttpMethod, string, string> WriteRoutes => new()
+    {
+        { HttpMethod.Post, "/api/alerts/acknowledge", """{"alertIds":[1],"isAcknowledged":true}""" },
+        { HttpMethod.Post, "/api/alerts/close", """{"alertIds":[1]}""" },
+        { HttpMethod.Put, "/api/alerts/1/notes", """{"notes":"hello"}""" },
+    };
+
+    [Theory]
+    [MemberData(nameof(WriteRoutes))]
+    public async Task WriteCapabilityDisabled_IsRefused_WithoutTouchingTheDatabase(
+        HttpMethod method, string path, string body)
+    {
+        _factory.Sql.Reset();
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization =
+            new AuthenticationHeaderValue("Bearer", _factory.TokenFor(AppRoles.Admin, []));
+
+        using var request = new HttpRequestMessage(method, path)
+        {
+            Content = new StringContent(body, System.Text.Encoding.UTF8, "application/json")
+        };
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        // Refused before any scope lookup or procedure call.
+        Assert.Equal(0, _factory.Sql.QueryCount);
+    }
+}
+
+/// <summary>
+/// Records every query and never touches SQL Server. Scope lookups resolve to no
+/// instances, which is the condition under test.
+/// </summary>
+public sealed class RecordingSqlDataService(IConfiguration configuration) : SqlDataService(configuration)
+{
+    public int QueryCount { get; private set; }
+
+    public string LastSql { get; private set; } = string.Empty;
+
+    public void Reset()
+    {
+        QueryCount = 0;
+        LastSql = string.Empty;
+    }
+
+    public override Task<List<Dictionary<string, object?>>> QueryAsync(
+        string sql,
+        CancellationToken cancellationToken,
+        params (string name, object? value)[] parameters)
+    {
+        QueryCount++;
+        LastSql = sql;
+        return Task.FromResult(new List<Dictionary<string, object?>>());
+    }
+}
+
+public sealed class AlertsWebApplicationFactory : WebApplicationFactory<Program>
+{
+    private readonly string _userStorePath =
+        Path.Combine(Path.GetTempPath(), $"dbadash-tests-{Guid.NewGuid():N}", "local-users.json");
+
+    /// Resolved on demand: touching Services builds the host, so this is valid
+    /// before the first CreateClient() call.
+    public RecordingSqlDataService Sql => Services.GetRequiredService<RecordingSqlDataService>();
+
+    public string TokenFor(string role, string[] allowedTags) =>
+        Services.GetRequiredService<JwtTokenService>()
+            .CreateToken("scoped-tester", "Scoped Tester", role, allowedTags);
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        // Development supplies the JWT fallback secret, so the host starts without
+        // any deployment configuration.
+        builder.UseEnvironment(Environments.Development);
+
+        builder.ConfigureAppConfiguration((_, config) => config.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:DBADashDB"] = "Server=(unused);Database=(unused);",
+            // Keep the bootstrap user store out of the repository.
+            ["LocalAuth:UserStorePath"] = _userStorePath,
+            ["LocalAuth:BootstrapAdminPassword"] = "tests-only-not-a-real-password",
+        }));
+
+        builder.ConfigureServices(services =>
+        {
+            services.RemoveAll<SqlDataService>();
+            services.AddSingleton<RecordingSqlDataService>();
+            services.AddSingleton<SqlDataService>(sp => sp.GetRequiredService<RecordingSqlDataService>());
+        });
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (!disposing) return;
+
+        var directory = Path.GetDirectoryName(_userStorePath);
+        if (directory is not null && Directory.Exists(directory))
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+}

--- a/backend.tests/DBADashWebView.Tests.csproj
+++ b/backend.tests/DBADashWebView.Tests.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/backend/Auth/AppAuthorization.cs
+++ b/backend/Auth/AppAuthorization.cs
@@ -18,4 +18,5 @@ public static class AppRoles
 public static class AppPolicies
 {
     public const string AdminOnly = "AdminOnly";
+    public const string OperatorOrAdmin = "OperatorOrAdmin";
 }

--- a/backend/Data/SqlDataService.cs
+++ b/backend/Data/SqlDataService.cs
@@ -3,7 +3,12 @@ using Microsoft.Data.SqlClient;
 
 namespace DBADashWebView.Data;
 
-public sealed class SqlDataService
+/// <remarks>
+/// Not sealed, and <see cref="QueryAsync(string, CancellationToken, ValueTuple{string, object}[])"/>
+/// is virtual, so endpoint tests can substitute a fake and exercise handlers that
+/// return before ever opening a connection.
+/// </remarks>
+public class SqlDataService
 {
     private readonly string _connectionString;
 
@@ -15,7 +20,7 @@ public sealed class SqlDataService
     public Task<List<Dictionary<string, object?>>> QueryAsync(string sql, params (string name, object? value)[] parameters) =>
         QueryAsync(sql, CancellationToken.None, parameters);
 
-    public async Task<List<Dictionary<string, object?>>> QueryAsync(
+    public virtual async Task<List<Dictionary<string, object?>>> QueryAsync(
         string sql,
         CancellationToken cancellationToken,
         params (string name, object? value)[] parameters)

--- a/backend/Endpoints/AlertsEndpointMappings.cs
+++ b/backend/Endpoints/AlertsEndpointMappings.cs
@@ -2,6 +2,7 @@ using System.Data;
 using System.Security.Claims;
 using DBADashWebView.Auth;
 using DBADashWebView.Data;
+using DBADashWebView.Settings;
 using Microsoft.Data.SqlClient;
 using Microsoft.Data.SqlClient.Server;
 
@@ -26,7 +27,7 @@ public static class AlertsEndpointMappings
 {
     public static IEndpointRouteBuilder MapAlertsEndpoints(this IEndpointRouteBuilder endpoints)
     {
-        endpoints.MapGet("/api/alerts/active", async (int? instanceId, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        endpoints.MapGet("/api/alerts/active", async (int? instanceId, ClaimsPrincipal user, SqlDataService sql, WriteCapabilityOptions writeCapabilities, ILogger<Program> logger, CancellationToken cancellationToken) =>
         {
             if (instanceId is int requestedInstanceId)
             {
@@ -37,6 +38,11 @@ public static class AlertsEndpointMappings
             try
             {
                 var allowedIds = await user.AllowedInstanceIdsAsync(sql, cancellationToken);
+                if (IsEmptyScope(allowedIds))
+                {
+                    return Results.Ok(EmptyScopeResponse(writeCapabilities));
+                }
+
                 await using var connection = await sql.OpenConnectionAsync(cancellationToken);
                 await using var command = new SqlCommand("Alert.ActiveAlerts_Get", connection)
                 {
@@ -47,7 +53,7 @@ public static class AlertsEndpointMappings
                 command.Parameters.AddWithValue("@InstanceID", (object?)instanceId ?? DBNull.Value);
 
                 var data = await EndpointResultMapper.ReadRowsAsync(command, cancellationToken, camelCase: true);
-                return Results.Ok(new { supported = true, data });
+                return Results.Ok(new { supported = true, canWrite = writeCapabilities.AlertLifecycle, data });
             }
             catch (SqlException ex) when (IsMissingAlertSchema(ex))
             {
@@ -55,11 +61,12 @@ public static class AlertsEndpointMappings
             }
             catch (Exception ex)
             {
-                return Results.Ok(new { supported = true, error = ex.Message, data = Array.Empty<object>() });
+                logger.LogError(ex, "Active alerts endpoint failed");
+                return Results.Problem(title: "Unable to read active alerts", statusCode: StatusCodes.Status500InternalServerError);
             }
         }).RequireAuthorization();
 
-        endpoints.MapGet("/api/alerts/closed", async (int? instanceId, int? top, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        endpoints.MapGet("/api/alerts/closed", async (int? instanceId, int? top, ClaimsPrincipal user, SqlDataService sql, WriteCapabilityOptions writeCapabilities, ILogger<Program> logger, CancellationToken cancellationToken) =>
         {
             if (instanceId is int requestedInstanceId)
             {
@@ -70,6 +77,11 @@ public static class AlertsEndpointMappings
             try
             {
                 var allowedIds = await user.AllowedInstanceIdsAsync(sql, cancellationToken);
+                if (IsEmptyScope(allowedIds))
+                {
+                    return Results.Ok(EmptyScopeResponse(writeCapabilities));
+                }
+
                 await using var connection = await sql.OpenConnectionAsync(cancellationToken);
                 await using var command = new SqlCommand("Alert.ClosedAlerts_Get", connection)
                 {
@@ -81,7 +93,7 @@ public static class AlertsEndpointMappings
                 command.Parameters.AddWithValue("@Top", Math.Clamp(top ?? 500, 1, 5000));
 
                 var data = await EndpointResultMapper.ReadRowsAsync(command, cancellationToken, camelCase: true);
-                return Results.Ok(new { supported = true, data });
+                return Results.Ok(new { supported = true, canWrite = writeCapabilities.AlertLifecycle, data });
             }
             catch (SqlException ex) when (IsMissingAlertSchema(ex))
             {
@@ -89,7 +101,8 @@ public static class AlertsEndpointMappings
             }
             catch (Exception ex)
             {
-                return Results.Ok(new { supported = true, error = ex.Message, data = Array.Empty<object>() });
+                logger.LogError(ex, "Closed alerts endpoint failed");
+                return Results.Problem(title: "Unable to read closed alerts", statusCode: StatusCodes.Status500InternalServerError);
             }
         }).RequireAuthorization();
 
@@ -97,18 +110,25 @@ public static class AlertsEndpointMappings
             AcknowledgeAlertsRequest request,
             ClaimsPrincipal user,
             SqlDataService sql,
+            WriteCapabilityOptions writeCapabilities,
             CancellationToken cancellationToken) =>
         {
+            if (WriteDisabledResult(writeCapabilities) is { } disabled) return disabled;
+
             if (request.AlertIds is null || request.AlertIds.Length == 0)
             {
                 return Results.Problem(title: "At least one alert id is required", statusCode: StatusCodes.Status400BadRequest);
             }
 
-            var scopeDenied = await EnsureAlertsInScopeAsync(user, sql, request.AlertIds, cancellationToken);
-            if (scopeDenied is not null) return scopeDenied;
-
             try
             {
+                // Kept inside the guarded block: on a pre-3.17 repository the scope
+                // check itself reads Alert.ActiveAlerts / Alert.ClosedAlerts, and
+                // outside the try it would throw straight past the compatibility
+                // handling below and surface as a 500 instead of supported = false.
+                var scopeDenied = await EnsureAlertsInScopeAsync(user, sql, request.AlertIds, cancellationToken);
+                if (scopeDenied is not null) return scopeDenied;
+
                 await using var connection = await sql.OpenConnectionAsync(cancellationToken);
                 await using var command = new SqlCommand("Alert.ActiveAlertsAck_Upd", connection)
                 {
@@ -132,18 +152,25 @@ public static class AlertsEndpointMappings
             CloseAlertsRequest request,
             ClaimsPrincipal user,
             SqlDataService sql,
+            WriteCapabilityOptions writeCapabilities,
             CancellationToken cancellationToken) =>
         {
+            if (WriteDisabledResult(writeCapabilities) is { } disabled) return disabled;
+
             if (request.AlertIds is null || request.AlertIds.Length == 0)
             {
                 return Results.Problem(title: "At least one alert id is required", statusCode: StatusCodes.Status400BadRequest);
             }
 
-            var scopeDenied = await EnsureAlertsInScopeAsync(user, sql, request.AlertIds, cancellationToken);
-            if (scopeDenied is not null) return scopeDenied;
-
             try
             {
+                // Kept inside the guarded block: on a pre-3.17 repository the scope
+                // check itself reads Alert.ActiveAlerts / Alert.ClosedAlerts, and
+                // outside the try it would throw straight past the compatibility
+                // handling below and surface as a 500 instead of supported = false.
+                var scopeDenied = await EnsureAlertsInScopeAsync(user, sql, request.AlertIds, cancellationToken);
+                if (scopeDenied is not null) return scopeDenied;
+
                 await using var connection = await sql.OpenConnectionAsync(cancellationToken);
                 await using var command = new SqlCommand("Alert.ClosedAlerts_Add", connection)
                 {
@@ -167,13 +194,20 @@ public static class AlertsEndpointMappings
             UpdateAlertNotesRequest request,
             ClaimsPrincipal user,
             SqlDataService sql,
+            WriteCapabilityOptions writeCapabilities,
             CancellationToken cancellationToken) =>
         {
-            var scopeDenied = await EnsureAlertsInScopeAsync(user, sql, [alertId], cancellationToken);
-            if (scopeDenied is not null) return scopeDenied;
+            if (WriteDisabledResult(writeCapabilities) is { } disabled) return disabled;
 
             try
             {
+                // Kept inside the guarded block: on a pre-3.17 repository the scope
+                // check itself reads Alert.ActiveAlerts / Alert.ClosedAlerts, and
+                // outside the try it would throw straight past the compatibility
+                // handling below and surface as a 500 instead of supported = false.
+                var scopeDenied = await EnsureAlertsInScopeAsync(user, sql, [alertId], cancellationToken);
+                if (scopeDenied is not null) return scopeDenied;
+
                 await using var connection = await sql.OpenConnectionAsync(cancellationToken);
                 await using var command = new SqlCommand("Alert.Alerts_Notes_Upd", connection)
                 {
@@ -198,9 +232,40 @@ public static class AlertsEndpointMappings
     private static readonly object AlertSchemaMissingResponse = new
     {
         supported = false,
+        canWrite = false,
         error = "This DBADashDB doesn't have DBA Dash's alert lifecycle schema (Alert.*). Alert acknowledge/close/notes requires DBA Dash 3.17.0 or later.",
         data = Array.Empty<object>()
     };
+
+    /// <summary>
+    /// True when the caller is scope-restricted (non-null set) but that scope
+    /// resolves to no instances at all.
+    ///
+    /// This must short-circuit before the stored procedure runs.
+    /// <c>Alert.ActiveAlerts_Get</c> derives its own flag with
+    /// <c>@AllInstances = CASE WHEN EXISTS(SELECT 1 FROM @InstanceIDs) THEN 0 ELSE 1 END</c>
+    /// and then filters with <c>... OR @AllInstances = 1</c>, so an empty
+    /// table-valued parameter does not mean "no instances" — it means "every
+    /// instance". Passing an empty scope through would hand a restricted user the
+    /// entire fleet's alerts. <c>Alert.ClosedAlerts_Get</c> follows the same shape.
+    /// </summary>
+    private static bool IsEmptyScope(HashSet<int>? allowedIds) => allowedIds is { Count: 0 };
+
+    private static object EmptyScopeResponse(WriteCapabilityOptions writeCapabilities) =>
+        new { supported = true, canWrite = writeCapabilities.AlertLifecycle, data = Array.Empty<object>() };
+
+    /// <summary>
+    /// Returns a 403 when the alert write capability is off, or <c>null</c> to let
+    /// the request through. Role alone is not enough: the deployment also has to be
+    /// provisioned with the EXECUTE grants these procedures need.
+    /// </summary>
+    private static IResult? WriteDisabledResult(WriteCapabilityOptions writeCapabilities) =>
+        writeCapabilities.AlertLifecycle
+            ? null
+            : Results.Problem(
+                title: "Alert write operations are disabled",
+                detail: "Set WriteCapabilities:AlertLifecycle to true and grant the EXECUTE permissions documented in the README.",
+                statusCode: StatusCodes.Status403Forbidden);
 
     private static bool IsMissingAlertSchema(SqlException ex) => IsMissingAlertSchema(ex.Number, ex.Message);
 

--- a/backend/Endpoints/AlertsEndpointMappings.cs
+++ b/backend/Endpoints/AlertsEndpointMappings.cs
@@ -1,0 +1,291 @@
+using System.Data;
+using System.Security.Claims;
+using DBADashWebView.Auth;
+using DBADashWebView.Data;
+using Microsoft.Data.SqlClient;
+using Microsoft.Data.SqlClient.Server;
+
+namespace DBADashWebView.Endpoints;
+
+public sealed record AcknowledgeAlertsRequest(long[] AlertIds, bool IsAcknowledged);
+
+public sealed record CloseAlertsRequest(long[] AlertIds);
+
+public sealed record UpdateAlertNotesRequest(string? Notes);
+
+/// <summary>
+/// Surfaces DBA Dash's real alert lifecycle (Alert.ActiveAlerts / Alert.ClosedAlerts)
+/// instead of the synthetic "collection errors + failed jobs" feed used elsewhere.
+/// All writes go through DBA Dash's own stored procedures (Alert.ActiveAlertsAck_Upd,
+/// Alert.ClosedAlerts_Add, Alert.Alerts_Notes_Upd) rather than direct table writes, per
+/// dba-dash's alert schema (introduced in DBA Dash 3.17.0). On older repositories these
+/// objects don't exist yet, so every call is guarded and reports that distinctly rather
+/// than as a generic error.
+/// </summary>
+public static class AlertsEndpointMappings
+{
+    public static IEndpointRouteBuilder MapAlertsEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/api/alerts/active", async (int? instanceId, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            if (instanceId is int requestedInstanceId)
+            {
+                var deny = await user.EnsureInstanceAccessAsync(requestedInstanceId, sql, cancellationToken);
+                if (deny is not null) return deny;
+            }
+
+            try
+            {
+                var allowedIds = await user.AllowedInstanceIdsAsync(sql, cancellationToken);
+                await using var connection = await sql.OpenConnectionAsync(cancellationToken);
+                await using var command = new SqlCommand("Alert.ActiveAlerts_Get", connection)
+                {
+                    CommandType = CommandType.StoredProcedure,
+                    CommandTimeout = 30
+                };
+                command.Parameters.Add(BuildIntIdsParameter("@InstanceIDs", allowedIds));
+                command.Parameters.AddWithValue("@InstanceID", (object?)instanceId ?? DBNull.Value);
+
+                var data = await EndpointResultMapper.ReadRowsAsync(command, cancellationToken, camelCase: true);
+                return Results.Ok(new { supported = true, data });
+            }
+            catch (SqlException ex) when (IsMissingAlertSchema(ex))
+            {
+                return Results.Ok(AlertSchemaMissingResponse);
+            }
+            catch (Exception ex)
+            {
+                return Results.Ok(new { supported = true, error = ex.Message, data = Array.Empty<object>() });
+            }
+        }).RequireAuthorization();
+
+        endpoints.MapGet("/api/alerts/closed", async (int? instanceId, int? top, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            if (instanceId is int requestedInstanceId)
+            {
+                var deny = await user.EnsureInstanceAccessAsync(requestedInstanceId, sql, cancellationToken);
+                if (deny is not null) return deny;
+            }
+
+            try
+            {
+                var allowedIds = await user.AllowedInstanceIdsAsync(sql, cancellationToken);
+                await using var connection = await sql.OpenConnectionAsync(cancellationToken);
+                await using var command = new SqlCommand("Alert.ClosedAlerts_Get", connection)
+                {
+                    CommandType = CommandType.StoredProcedure,
+                    CommandTimeout = 30
+                };
+                command.Parameters.Add(BuildIntIdsParameter("@InstanceIDs", allowedIds));
+                command.Parameters.AddWithValue("@InstanceID", (object?)instanceId ?? DBNull.Value);
+                command.Parameters.AddWithValue("@Top", Math.Clamp(top ?? 500, 1, 5000));
+
+                var data = await EndpointResultMapper.ReadRowsAsync(command, cancellationToken, camelCase: true);
+                return Results.Ok(new { supported = true, data });
+            }
+            catch (SqlException ex) when (IsMissingAlertSchema(ex))
+            {
+                return Results.Ok(AlertSchemaMissingResponse);
+            }
+            catch (Exception ex)
+            {
+                return Results.Ok(new { supported = true, error = ex.Message, data = Array.Empty<object>() });
+            }
+        }).RequireAuthorization();
+
+        endpoints.MapPost("/api/alerts/acknowledge", async (
+            AcknowledgeAlertsRequest request,
+            ClaimsPrincipal user,
+            SqlDataService sql,
+            CancellationToken cancellationToken) =>
+        {
+            if (request.AlertIds is null || request.AlertIds.Length == 0)
+            {
+                return Results.Problem(title: "At least one alert id is required", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var scopeDenied = await EnsureAlertsInScopeAsync(user, sql, request.AlertIds, cancellationToken);
+            if (scopeDenied is not null) return scopeDenied;
+
+            try
+            {
+                await using var connection = await sql.OpenConnectionAsync(cancellationToken);
+                await using var command = new SqlCommand("Alert.ActiveAlertsAck_Upd", connection)
+                {
+                    CommandType = CommandType.StoredProcedure,
+                    CommandTimeout = 30
+                };
+                command.Parameters.Add(BuildBigIntIdsParameter("@AlertIDs", request.AlertIds));
+                command.Parameters.AddWithValue("@AlertID", DBNull.Value);
+                command.Parameters.AddWithValue("@IsAcknowledged", request.IsAcknowledged);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+
+                return Results.Ok(new { success = true });
+            }
+            catch (SqlException ex) when (IsMissingAlertSchema(ex))
+            {
+                return Results.Ok(AlertSchemaMissingResponse);
+            }
+        }).RequireAuthorization(AppPolicies.OperatorOrAdmin);
+
+        endpoints.MapPost("/api/alerts/close", async (
+            CloseAlertsRequest request,
+            ClaimsPrincipal user,
+            SqlDataService sql,
+            CancellationToken cancellationToken) =>
+        {
+            if (request.AlertIds is null || request.AlertIds.Length == 0)
+            {
+                return Results.Problem(title: "At least one alert id is required", statusCode: StatusCodes.Status400BadRequest);
+            }
+
+            var scopeDenied = await EnsureAlertsInScopeAsync(user, sql, request.AlertIds, cancellationToken);
+            if (scopeDenied is not null) return scopeDenied;
+
+            try
+            {
+                await using var connection = await sql.OpenConnectionAsync(cancellationToken);
+                await using var command = new SqlCommand("Alert.ClosedAlerts_Add", connection)
+                {
+                    CommandType = CommandType.StoredProcedure,
+                    CommandTimeout = 30
+                };
+                command.Parameters.Add(BuildBigIntIdsParameter("@AlertIDs", request.AlertIds));
+                command.Parameters.AddWithValue("@AlertID", DBNull.Value);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+
+                return Results.Ok(new { success = true });
+            }
+            catch (SqlException ex) when (IsMissingAlertSchema(ex))
+            {
+                return Results.Ok(AlertSchemaMissingResponse);
+            }
+        }).RequireAuthorization(AppPolicies.OperatorOrAdmin);
+
+        endpoints.MapPut("/api/alerts/{alertId:long}/notes", async (
+            long alertId,
+            UpdateAlertNotesRequest request,
+            ClaimsPrincipal user,
+            SqlDataService sql,
+            CancellationToken cancellationToken) =>
+        {
+            var scopeDenied = await EnsureAlertsInScopeAsync(user, sql, [alertId], cancellationToken);
+            if (scopeDenied is not null) return scopeDenied;
+
+            try
+            {
+                await using var connection = await sql.OpenConnectionAsync(cancellationToken);
+                await using var command = new SqlCommand("Alert.Alerts_Notes_Upd", connection)
+                {
+                    CommandType = CommandType.StoredProcedure,
+                    CommandTimeout = 30
+                };
+                command.Parameters.AddWithValue("@AlertID", alertId);
+                command.Parameters.AddWithValue("@Notes", (object?)request.Notes ?? DBNull.Value);
+                await command.ExecuteNonQueryAsync(cancellationToken);
+
+                return Results.Ok(new { success = true });
+            }
+            catch (SqlException ex) when (IsMissingAlertSchema(ex))
+            {
+                return Results.Ok(AlertSchemaMissingResponse);
+            }
+        }).RequireAuthorization(AppPolicies.OperatorOrAdmin);
+
+        return endpoints;
+    }
+
+    private static readonly object AlertSchemaMissingResponse = new
+    {
+        supported = false,
+        error = "This DBADashDB doesn't have DBA Dash's alert lifecycle schema (Alert.*). Alert acknowledge/close/notes requires DBA Dash 3.17.0 or later.",
+        data = Array.Empty<object>()
+    };
+
+    private static bool IsMissingAlertSchema(SqlException ex) => IsMissingAlertSchema(ex.Number, ex.Message);
+
+    /// <summary>
+    /// 208 = "Invalid object name" (proc/table doesn't exist), 2812 = "Could not find
+    /// stored procedure". Split out from the <see cref="SqlException"/> overload so it
+    /// can be unit tested without needing to construct a real SqlException.
+    /// </summary>
+    internal static bool IsMissingAlertSchema(int errorNumber, string message) =>
+        (errorNumber == 208 || errorNumber == 2812) && message.Contains("Alert.", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Verifies every alert id belongs to an instance the caller is allowed to see
+    /// (checking both ActiveAlerts and ClosedAlerts, since notes can target either).
+    /// No-op when the caller is unrestricted.
+    /// </summary>
+    private static async Task<IResult?> EnsureAlertsInScopeAsync(
+        ClaimsPrincipal user,
+        SqlDataService sql,
+        long[] alertIds,
+        CancellationToken cancellationToken)
+    {
+        var allowedIds = await user.AllowedInstanceIdsAsync(sql, cancellationToken);
+        if (allowedIds is null)
+        {
+            return null;
+        }
+
+        await using var connection = await sql.OpenConnectionAsync(cancellationToken);
+        await using var command = new SqlCommand(
+            """
+            SELECT DISTINCT InstanceID FROM Alert.ActiveAlerts WHERE AlertID IN (SELECT ID FROM @AlertIDs)
+            UNION
+            SELECT DISTINCT InstanceID FROM Alert.ClosedAlerts WHERE AlertID IN (SELECT ID FROM @AlertIDs)
+            """,
+            connection)
+        {
+            CommandTimeout = 30
+        };
+        command.Parameters.Add(BuildBigIntIdsParameter("@AlertIDs", alertIds));
+
+        var rows = await EndpointResultMapper.ReadRowsAsync(command, cancellationToken, camelCase: false);
+        foreach (var row in rows)
+        {
+            if (row.TryGetValue("InstanceID", out var value) && value is not null && !allowedIds.Contains(Convert.ToInt32(value)))
+            {
+                return Results.Forbid();
+            }
+        }
+
+        return null;
+    }
+
+    internal static SqlParameter BuildIntIdsParameter(string parameterName, HashSet<int>? ids)
+    {
+        var records = (ids ?? []).Select(id =>
+        {
+            var record = new SqlDataRecord(new SqlMetaData("ID", SqlDbType.Int));
+            record.SetInt32(0, id);
+            return record;
+        }).ToList();
+
+        // SqlClient rejects an empty IEnumerable<SqlDataRecord> for a structured
+        // parameter ("There are no records in the SqlDataRecord enumeration...") -
+        // a zero-row table-valued parameter must be sent as null instead.
+        return new SqlParameter(parameterName, SqlDbType.Structured)
+        {
+            TypeName = "dbo.IDs",
+            Value = records.Count > 0 ? records : null
+        };
+    }
+
+    internal static SqlParameter BuildBigIntIdsParameter(string parameterName, IEnumerable<long> ids)
+    {
+        var records = ids.Distinct().Select(id =>
+        {
+            var record = new SqlDataRecord(new SqlMetaData("ID", SqlDbType.BigInt));
+            record.SetInt64(0, id);
+            return record;
+        }).ToList();
+
+        return new SqlParameter(parameterName, SqlDbType.Structured)
+        {
+            TypeName = "dbo.BigIDs",
+            Value = records.Count > 0 ? records : null
+        };
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -39,7 +39,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         };
     });
 builder.Services.AddAuthorizationBuilder()
-    .AddPolicy(AppPolicies.AdminOnly, policy => policy.RequireRole(AppRoles.Admin));
+    .AddPolicy(AppPolicies.AdminOnly, policy => policy.RequireRole(AppRoles.Admin))
+    .AddPolicy(AppPolicies.OperatorOrAdmin, policy => policy.RequireRole(AppRoles.Admin, AppRoles.Operator));
 
 builder.Services.AddCors(options => options.AddDefaultPolicy(policy =>
 {
@@ -99,6 +100,7 @@ app.MapPerformanceEndpoints();
 app.MapMonitoringEndpoints();
 app.MapEstateEndpoints();
 app.MapReportEndpoints();
+app.MapAlertsEndpoints();
 
 app.MapFallbackToFile("index.html");
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -23,6 +23,7 @@ if (string.IsNullOrWhiteSpace(jwtOptions.Secret))
 
 var signingKey = new SymmetricSecurityKey(System.Text.Encoding.UTF8.GetBytes(jwtOptions.Secret));
 var corsSettings = builder.Configuration.GetSection("Cors").Get<CorsSettings>() ?? new CorsSettings();
+var writeCapabilities = builder.Configuration.GetSection(WriteCapabilityOptions.SectionName).Get<WriteCapabilityOptions>() ?? new WriteCapabilityOptions();
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(options =>
@@ -64,6 +65,7 @@ builder.Services.AddSingleton<LocalUserStore>();
 builder.Services.AddSingleton<ActiveDirectoryAuthService>();
 builder.Services.AddSingleton<ThresholdSettingsStore>();
 builder.Services.AddSingleton<SqlDataService>();
+builder.Services.AddSingleton(writeCapabilities);
 builder.Services.AddSingleton<ApplicationVersionProvider>();
 
 var app = builder.Build();

--- a/backend/Settings/WriteCapabilityOptions.cs
+++ b/backend/Settings/WriteCapabilityOptions.cs
@@ -1,0 +1,21 @@
+namespace DBADashWebView.Settings;
+
+/// <summary>
+/// Opt-in write capabilities.
+///
+/// WebView is documented and provisioned as <c>db_datareader</c> on DBADashDB, so
+/// every feature that writes stays off unless an operator both enables it here and
+/// grants the extra EXECUTE permissions listed in the README. Without that, the UI
+/// would offer buttons that can only ever fail with a permission error.
+/// </summary>
+public sealed class WriteCapabilityOptions
+{
+    public const string SectionName = "WriteCapabilities";
+
+    /// <summary>
+    /// Enables alert acknowledge / close / notes. Requires EXECUTE on
+    /// <c>Alert.ActiveAlertsAck_Upd</c>, <c>Alert.ClosedAlerts_Add</c> and
+    /// <c>Alert.Alerts_Notes_Upd</c>.
+    /// </summary>
+    public bool AlertLifecycle { get; set; }
+}

--- a/backend/appsettings.json
+++ b/backend/appsettings.json
@@ -24,5 +24,8 @@
     "BootstrapAdminUsername": "admin",
     "BootstrapAdminDisplayName": "Administrator",
     "BootstrapAdminPassword": ""
+  },
+  "WriteCapabilities": {
+    "AlertLifecycle": false
   }
 }

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -1,7 +1,10 @@
 import { clearAuthSession, getAuthSession, isAuthenticated, setAuthSession } from '../auth/session';
 import type {
+  AcknowledgeAlertsRequest,
+  ActiveAlertRow,
   AdConfig,
   AdLoginTestResult,
+  AlertLifecycleResponse,
   ApplicationVersionResponse,
   AvailabilityGroupSummaryRow,
   BackupAmpelResponse,
@@ -10,6 +13,8 @@ import type {
   ApiErrorShape,
   ApiRow,
   AuthStatusResponse,
+  ClosedAlertRow,
+  CloseAlertsRequest,
   CreateLocalUserRequest,
   DbSpaceRow,
   EstateBackupRow,
@@ -51,6 +56,7 @@ import type {
   ThresholdMap,
   TreeInstanceNode,
   UnderutilizedReportRow,
+  UpdateAlertNotesRequest,
   UpdateLocalUserRequest,
   WaitTimelineRow,
 } from './types';
@@ -229,4 +235,14 @@ export const api = {
     request<LocalUser>('/api/settings/users', { method: 'POST', body: JSON.stringify(payload) }),
   updateLocalUser: (id: string, payload: UpdateLocalUserRequest) =>
     request<LocalUser>(`/api/settings/users/${id}`, { method: 'PUT', body: JSON.stringify(payload) }),
+  alertsActive: (instanceId?: number) =>
+    request<AlertLifecycleResponse<ActiveAlertRow>>(`/api/alerts/active${instanceId ? `?instanceId=${instanceId}` : ''}`),
+  alertsClosed: (instanceId?: number, top = 500) =>
+    request<AlertLifecycleResponse<ClosedAlertRow>>(`/api/alerts/closed?top=${top}${instanceId ? `&instanceId=${instanceId}` : ''}`),
+  acknowledgeAlerts: (payload: AcknowledgeAlertsRequest) =>
+    request<{ success: boolean }>('/api/alerts/acknowledge', { method: 'POST', body: JSON.stringify(payload) }),
+  closeAlerts: (payload: CloseAlertsRequest) =>
+    request<{ success: boolean }>('/api/alerts/close', { method: 'POST', body: JSON.stringify(payload) }),
+  updateAlertNotes: (alertId: number, payload: UpdateAlertNotesRequest) =>
+    request<{ success: boolean }>(`/api/alerts/${alertId}/notes`, { method: 'PUT', body: JSON.stringify(payload) }),
 };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -808,6 +808,13 @@ export interface ClosedAlertRow extends ApiRow {
 
 export interface AlertLifecycleResponse<T> {
   supported: boolean;
+  /**
+   * Whether the deployment opted into alert writes. Read access does not imply
+   * write access: the procedures need EXECUTE grants a db_datareader install
+   * will not have, so the UI hides the actions rather than offering buttons
+   * that can only fail.
+   */
+  canWrite?: boolean;
   error?: string;
   data: T[];
 }

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -757,3 +757,70 @@ export interface DbSpaceRow extends ApiRow {
   growth?: number | null;
   isPercentGrowth?: boolean | number | null;
 }
+
+// DBA Dash's real alert lifecycle (Alert.ActiveAlerts / Alert.ClosedAlerts),
+// as opposed to the synthetic collection-error/failed-job feed on /api/alerts/recent.
+export interface ActiveAlertRow extends ApiRow {
+  alertID: number;
+  instanceID: number;
+  instanceDisplayName?: string | null;
+  priority: number;
+  priorityDescription?: string | null;
+  alertType?: string | null;
+  alertKey?: string | null;
+  firstMessage?: string | null;
+  lastMessage?: string | null;
+  triggerDate?: string | null;
+  alertDuration?: string | null;
+  updatedDate?: string | null;
+  timeSinceLastUpdate?: string | null;
+  updateCount?: number | null;
+  isAcknowledged: boolean;
+  isResolved: boolean;
+  resolvedDate?: string | null;
+  isBlackout: boolean;
+  alertStatus?: number | null;
+  notes?: string | null;
+  groupName?: string | null;
+  ruleNotes?: string | null;
+}
+
+export interface ClosedAlertRow extends ApiRow {
+  alertID: number;
+  instanceID: number;
+  instanceDisplayName?: string | null;
+  priority: number;
+  priorityDescription?: string | null;
+  alertType?: string | null;
+  alertKey?: string | null;
+  firstMessage?: string | null;
+  lastMessage?: string | null;
+  triggerDate?: string | null;
+  alertDuration?: string | null;
+  isAcknowledged: boolean;
+  isResolved: boolean;
+  resolvedDate?: string | null;
+  notes?: string | null;
+  closedDate?: string | null;
+  groupName?: string | null;
+  ruleNotes?: string | null;
+}
+
+export interface AlertLifecycleResponse<T> {
+  supported: boolean;
+  error?: string;
+  data: T[];
+}
+
+export interface AcknowledgeAlertsRequest {
+  alertIds: number[];
+  isAcknowledged: boolean;
+}
+
+export interface CloseAlertsRequest {
+  alertIds: number[];
+}
+
+export interface UpdateAlertNotesRequest {
+  notes?: string;
+}

--- a/frontend/src/components/DbaDashAlertsPanel.tsx
+++ b/frontend/src/components/DbaDashAlertsPanel.tsx
@@ -26,7 +26,7 @@ function isActiveAlert(alert: AlertRow): alert is ActiveAlertRow {
 }
 
 export default function DbaDashAlertsPanel({ instanceId }: { instanceId?: number }) {
-  const canAct = hasRole(['Admin', 'Operator']);
+  const hasWriteRole = hasRole(['Admin', 'Operator']);
   const [tab, setTab] = useState<Tab>('active');
   const [rows, setRows] = useState<AlertRow[]>([]);
   const [loading, setLoading] = useState(true);
@@ -36,6 +36,11 @@ export default function DbaDashAlertsPanel({ instanceId }: { instanceId?: number
   const [busy, setBusy] = useState(false);
   const [notesTarget, setNotesTarget] = useState<AlertRow | null>(null);
   const [notesDraft, setNotesDraft] = useState('');
+  const [writeEnabled, setWriteEnabled] = useState(false);
+
+  // Both must hold: the signed-in user's role, and the deployment having opted
+  // into alert writes with the EXECUTE grants they need.
+  const canAct = hasWriteRole && writeEnabled;
 
   useEffect(() => {
     setSelected(new Set());
@@ -49,10 +54,12 @@ export default function DbaDashAlertsPanel({ instanceId }: { instanceId?: number
     try {
       const response = tab === 'active' ? await api.alertsActive(instanceId) : await api.alertsClosed(instanceId);
       setSupported(response.supported);
+      setWriteEnabled(response.canWrite === true);
       setRows(Array.isArray(response.data) ? response.data : []);
       if (response.error) setError(response.error);
     } catch (err) {
       setRows([]);
+      setWriteEnabled(false);
       setError(err instanceof Error ? err.message : 'Unable to load alerts.');
     } finally {
       setLoading(false);
@@ -140,6 +147,14 @@ export default function DbaDashAlertsPanel({ instanceId }: { instanceId?: number
           </div>
         )}
       </div>
+
+      {supported && hasWriteRole && !writeEnabled && (
+        <p className="text-xs text-gray-500">
+          Acknowledge, close and notes are read-only here: this deployment has not enabled{' '}
+          <code>WriteCapabilities:AlertLifecycle</code>. See the README for the setting and the
+          EXECUTE grants it needs.
+        </p>
+      )}
 
       {!supported && (
         <div className="glass rounded-xl p-6 flex items-start gap-3 border border-yellow-500/20">

--- a/frontend/src/components/DbaDashAlertsPanel.tsx
+++ b/frontend/src/components/DbaDashAlertsPanel.tsx
@@ -1,0 +1,280 @@
+import { useEffect, useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+import { formatDistanceToNow } from 'date-fns';
+import {
+  CheckCircle2, Circle, Loader2, Lock, MessageSquare, ShieldOff, X, XCircle,
+} from 'lucide-react';
+import { clsx } from 'clsx';
+import { api } from '../api/api';
+import type { ActiveAlertRow, ClosedAlertRow } from '../api/types';
+import { getAuthSession, hasRole } from '../auth/session';
+import TabNav from './TabNav';
+
+type AlertRow = ActiveAlertRow | ClosedAlertRow;
+type Tab = 'active' | 'closed';
+
+function priorityBadge(priority: number): { label: string; className: string } {
+  if (priority === 0) return { label: 'Critical', className: 'bg-red-500/15 text-red-300 border-red-500/30' };
+  if (priority <= 10) return { label: 'High', className: 'bg-orange-500/15 text-orange-300 border-orange-500/30' };
+  if (priority <= 20) return { label: 'Medium', className: 'bg-yellow-500/15 text-yellow-300 border-yellow-500/30' };
+  if (priority <= 30) return { label: 'Low', className: 'bg-blue-500/15 text-blue-300 border-blue-500/30' };
+  return { label: 'Info', className: 'bg-white/10 text-gray-300 border-white/20' };
+}
+
+function isActiveAlert(alert: AlertRow): alert is ActiveAlertRow {
+  return 'isBlackout' in alert;
+}
+
+export default function DbaDashAlertsPanel({ instanceId }: { instanceId?: number }) {
+  const canAct = hasRole(['Admin', 'Operator']);
+  const [tab, setTab] = useState<Tab>('active');
+  const [rows, setRows] = useState<AlertRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [supported, setSupported] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selected, setSelected] = useState<Set<number>>(new Set());
+  const [busy, setBusy] = useState(false);
+  const [notesTarget, setNotesTarget] = useState<AlertRow | null>(null);
+  const [notesDraft, setNotesDraft] = useState('');
+
+  useEffect(() => {
+    setSelected(new Set());
+    load();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tab, instanceId]);
+
+  async function load() {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = tab === 'active' ? await api.alertsActive(instanceId) : await api.alertsClosed(instanceId);
+      setSupported(response.supported);
+      setRows(Array.isArray(response.data) ? response.data : []);
+      if (response.error) setError(response.error);
+    } catch (err) {
+      setRows([]);
+      setError(err instanceof Error ? err.message : 'Unable to load alerts.');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function toggleSelected(alertId: number) {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(alertId)) next.delete(alertId); else next.add(alertId);
+      return next;
+    });
+  }
+
+  async function handleAcknowledge(alertIds: number[], isAcknowledged: boolean) {
+    setBusy(true);
+    try {
+      await api.acknowledgeAlerts({ alertIds, isAcknowledged });
+      setSelected(new Set());
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to acknowledge alert(s).');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleClose(alertIds: number[]) {
+    setBusy(true);
+    try {
+      await api.closeAlerts({ alertIds });
+      setSelected(new Set());
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to close alert(s).');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function handleSaveNotes() {
+    if (!notesTarget) return;
+    setBusy(true);
+    try {
+      await api.updateAlertNotes(notesTarget.alertID, { notes: notesDraft || undefined });
+      setNotesTarget(null);
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to save notes.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const selectedCount = selected.size;
+
+  const tabs = useMemo(() => [
+    { key: 'active', label: 'Active' },
+    { key: 'closed', label: 'History' },
+  ], []);
+
+  if (!getAuthSession()) return null;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between flex-wrap gap-3">
+        <TabNav tabs={tabs} active={tab} onChange={key => setTab(key as Tab)} />
+        {canAct && selectedCount > 0 && tab === 'active' && (
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs text-gray-400">{selectedCount} selected</span>
+            <button
+              disabled={busy}
+              onClick={() => handleAcknowledge(Array.from(selected), true)}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-500/20 text-blue-300 rounded-lg text-xs hover:bg-blue-500/30 disabled:opacity-50"
+            >
+              <CheckCircle2 className="w-3.5 h-3.5" /> Acknowledge
+            </button>
+            <button
+              disabled={busy}
+              onClick={() => handleClose(Array.from(selected))}
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-emerald-500/20 text-emerald-300 rounded-lg text-xs hover:bg-emerald-500/30 disabled:opacity-50"
+            >
+              <XCircle className="w-3.5 h-3.5" /> Close
+            </button>
+          </div>
+        )}
+      </div>
+
+      {!supported && (
+        <div className="glass rounded-xl p-6 flex items-start gap-3 border border-yellow-500/20">
+          <Lock className="w-5 h-5 text-yellow-400 flex-shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm text-yellow-200 font-medium">DBA Dash alert lifecycle unavailable</p>
+            <p className="text-xs text-gray-400 mt-1">{error || 'This DBADashDB does not have the Alert schema. Upgrade to DBA Dash 3.17.0+ to enable acknowledge/close/notes.'}</p>
+          </div>
+        </div>
+      )}
+
+      {supported && error && (
+        <div className="rounded-lg bg-red-500/10 px-4 py-2 text-sm text-red-300">{error}</div>
+      )}
+
+      {supported && loading && (
+        <div className="flex items-center gap-2 text-gray-400 py-8 justify-center">
+          <Loader2 className="w-4 h-4 animate-spin" /> Loading alerts...
+        </div>
+      )}
+
+      {supported && !loading && (
+        <div className="space-y-2">
+          {rows.map(alert => {
+            const badge = priorityBadge(alert.priority);
+            const active = isActiveAlert(alert);
+            return (
+              <motion.div
+                key={alert.alertID}
+                initial={{ opacity: 0, y: 4 }}
+                animate={{ opacity: 1, y: 0 }}
+                className="glass rounded-xl p-4 border border-white/5"
+              >
+                <div className="flex items-start gap-3">
+                  {canAct && tab === 'active' && (
+                    <button onClick={() => toggleSelected(alert.alertID)} className="mt-0.5 flex-shrink-0">
+                      {selected.has(alert.alertID)
+                        ? <CheckCircle2 className="w-4 h-4 text-blue-400" />
+                        : <Circle className="w-4 h-4 text-gray-600" />}
+                    </button>
+                  )}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 flex-wrap mb-1">
+                      <span className={clsx('text-[10px] px-1.5 py-0.5 rounded font-semibold uppercase border', badge.className)}>
+                        {badge.label}
+                      </span>
+                      <span className="text-xs font-medium text-gray-300">{alert.instanceDisplayName}</span>
+                      <span className="text-[10px] text-gray-500">{alert.alertType} · {alert.alertKey}</span>
+                      {active && alert.isAcknowledged && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-blue-500/10 text-blue-300">Acknowledged</span>
+                      )}
+                      {active && alert.isBlackout && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-purple-500/10 text-purple-300 flex items-center gap-1">
+                          <ShieldOff className="w-3 h-3" /> Blackout
+                        </span>
+                      )}
+                      {alert.isResolved && (
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-emerald-500/10 text-emerald-300">Resolved</span>
+                      )}
+                      <span className="text-[10px] text-gray-500 ml-auto">
+                        {alert.triggerDate ? formatDistanceToNow(new Date(alert.triggerDate), { addSuffix: true }) : ''}
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-300 leading-snug">{alert.lastMessage || alert.firstMessage}</p>
+                    {alert.notes && (
+                      <p className="text-xs text-gray-500 mt-1.5 bg-white/5 rounded-lg px-2.5 py-1.5">{alert.notes}</p>
+                    )}
+                    <div className="flex items-center gap-3 mt-2">
+                      <button
+                        onClick={() => { setNotesTarget(alert); setNotesDraft(alert.notes || ''); }}
+                        className="flex items-center gap-1 text-[11px] text-gray-400 hover:text-white transition-colors"
+                      >
+                        <MessageSquare className="w-3 h-3" /> {alert.notes ? 'Edit notes' : 'Add notes'}
+                      </button>
+                      {canAct && tab === 'active' && (
+                        <>
+                          <button
+                            disabled={busy}
+                            onClick={() => handleAcknowledge([alert.alertID], !active || !alert.isAcknowledged)}
+                            className="text-[11px] text-blue-400 hover:text-blue-300 transition-colors disabled:opacity-50"
+                          >
+                            {active && alert.isAcknowledged ? 'Un-acknowledge' : 'Acknowledge'}
+                          </button>
+                          <button
+                            disabled={busy}
+                            onClick={() => handleClose([alert.alertID])}
+                            className="text-[11px] text-emerald-400 hover:text-emerald-300 transition-colors disabled:opacity-50"
+                          >
+                            Close
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </motion.div>
+            );
+          })}
+          {rows.length === 0 && (
+            <div className="glass rounded-xl p-10 text-center text-sm text-gray-500">
+              {tab === 'active' ? 'No active alerts.' : 'No closed alerts yet.'}
+            </div>
+          )}
+        </div>
+      )}
+
+      {notesTarget && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50" onClick={() => setNotesTarget(null)}>
+          <div className="glass rounded-xl p-6 w-[28rem] gradient-border" onClick={e => e.stopPropagation()}>
+            <div className="flex items-center justify-between mb-4">
+              <h3 className="text-lg font-semibold text-white">Alert Notes</h3>
+              <button onClick={() => setNotesTarget(null)} className="text-gray-400 hover:text-white"><X className="w-5 h-5" /></button>
+            </div>
+            <textarea
+              value={notesDraft}
+              onChange={e => setNotesDraft(e.target.value)}
+              rows={6}
+              placeholder="Root cause, follow-up, links..."
+              className="w-full bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-white text-sm resize-none"
+              readOnly={!canAct}
+            />
+            {canAct ? (
+              <button
+                onClick={handleSaveNotes}
+                disabled={busy}
+                className="w-full mt-3 py-2 bg-blue-500 hover:bg-blue-600 text-white rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+              >
+                {busy ? 'Saving...' : 'Save Notes'}
+              </button>
+            ) : (
+              <p className="text-xs text-gray-500 mt-2">Viewer role can't edit notes.</p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/DbaDashAlertsPanel.tsx
+++ b/frontend/src/components/DbaDashAlertsPanel.tsx
@@ -223,12 +223,15 @@ export default function DbaDashAlertsPanel({ instanceId }: { instanceId?: number
                       <p className="text-xs text-gray-500 mt-1.5 bg-white/5 rounded-lg px-2.5 py-1.5">{alert.notes}</p>
                     )}
                     <div className="flex items-center gap-3 mt-2">
-                      <button
-                        onClick={() => { setNotesTarget(alert); setNotesDraft(alert.notes || ''); }}
-                        className="flex items-center gap-1 text-[11px] text-gray-400 hover:text-white transition-colors"
-                      >
-                        <MessageSquare className="w-3 h-3" /> {alert.notes ? 'Edit notes' : 'Add notes'}
-                      </button>
+                      {(canAct || alert.notes) && (
+                        <button
+                          onClick={() => { setNotesTarget(alert); setNotesDraft(alert.notes || ''); }}
+                          className="flex items-center gap-1 text-[11px] text-gray-400 hover:text-white transition-colors"
+                        >
+                          <MessageSquare className="w-3 h-3" />
+                          {canAct ? (alert.notes ? 'Edit notes' : 'Add notes') : 'View notes'}
+                        </button>
+                      )}
                       {canAct && tab === 'active' && (
                         <>
                           <button
@@ -285,7 +288,11 @@ export default function DbaDashAlertsPanel({ instanceId }: { instanceId?: number
                 {busy ? 'Saving...' : 'Save Notes'}
               </button>
             ) : (
-              <p className="text-xs text-gray-500 mt-2">Viewer role can't edit notes.</p>
+              <p className="text-xs text-gray-500 mt-2">
+                  {hasWriteRole
+                    ? 'Notes are read-only: this deployment has not enabled WriteCapabilities:AlertLifecycle.'
+                    : "Your role can't edit notes."}
+                </p>
             )}
           </div>
         </div>

--- a/frontend/src/pages/AlertsPage.test.tsx
+++ b/frontend/src/pages/AlertsPage.test.tsx
@@ -1,0 +1,50 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import AlertsPage from './AlertsPage';
+
+const apiMocks = vi.hoisted(() => ({
+  instances: vi.fn(() => new Promise<never>(() => {})),
+  alertsRecent: vi.fn(() => new Promise<never>(() => {})),
+}));
+
+vi.mock('../App', () => ({
+  useRefresh: () => ({ lastRefresh: new Date(0), refresh: () => {} }),
+}));
+
+vi.mock('../api/api', () => ({ api: apiMocks }));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  apiMocks.instances.mockClear();
+  apiMocks.alertsRecent.mockClear();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('AlertsPage', () => {
+  it('opens SQL Monitor deep links in the filtered legacy alerts feed', () => {
+    act(() => {
+      root.render(
+        <MemoryRouter initialEntries={['/alerts?instance=42&type=collection-errors']}>
+          <AlertsPage />
+        </MemoryRouter>
+      );
+    });
+
+    const legacyTab = Array.from(container.querySelectorAll('button'))
+      .find(button => button.textContent === 'Collection Errors & Failed Jobs');
+
+    expect(legacyTab?.className).toContain('bg-blue-500/20');
+    expect(apiMocks.alertsRecent).toHaveBeenCalledWith(42);
+  });
+});

--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -87,7 +87,10 @@ const SEV_CONFIG = {
 /* ── Component ── */
 
 export default function AlertsPage() {
-  const [pageTab, setPageTab] = useState<'dbadash' | 'legacy'>('dbadash');
+  const [searchParams] = useSearchParams();
+  const [pageTab, setPageTab] = useState<'dbadash' | 'legacy'>(() =>
+    searchParams.has('instance') || searchParams.has('type') ? 'legacy' : 'dbadash'
+  );
   const [legacyInstanceId, setLegacyInstanceId] = useState<number | undefined>(undefined);
 
   return (

--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -11,6 +11,8 @@ import {
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { format, formatDistanceToNow } from 'date-fns';
+import DbaDashAlertsPanel from '../components/DbaDashAlertsPanel';
+import TabNav from '../components/TabNav';
 import { alertCategoryBySlug } from '../utils/alertCategories';
 
 /* ── Helpers ── */
@@ -85,6 +87,37 @@ const SEV_CONFIG = {
 /* ── Component ── */
 
 export default function AlertsPage() {
+  const [pageTab, setPageTab] = useState<'dbadash' | 'legacy'>('dbadash');
+  const [legacyInstanceId, setLegacyInstanceId] = useState<number | undefined>(undefined);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between flex-wrap gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-white">Alerts</h1>
+          <p className="text-xs text-gray-500 mt-1">
+            {pageTab === 'dbadash'
+              ? "DBA Dash's alert engine — acknowledge, close, and annotate"
+              : 'Collection errors and failed jobs · newest first · auto-refresh 30s'}
+          </p>
+        </div>
+        <TabNav
+          tabs={[
+            { key: 'dbadash', label: 'DBA Dash Alerts' },
+            { key: 'legacy', label: 'Collection Errors & Failed Jobs' },
+          ]}
+          active={pageTab}
+          onChange={key => setPageTab(key as 'dbadash' | 'legacy')}
+        />
+      </div>
+
+      {pageTab === 'dbadash' && <DbaDashAlertsPanel instanceId={legacyInstanceId} />}
+      {pageTab === 'legacy' && <CollectionErrorsFeed onInstanceChange={setLegacyInstanceId} />}
+    </div>
+  );
+}
+
+function CollectionErrorsFeed({ onInstanceChange }: { onInstanceChange: (instanceId: number | undefined) => void }) {
   const { lastRefresh } = useRefresh();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
@@ -121,6 +154,10 @@ export default function AlertsPage() {
       .catch(() => setInstances([]))
       .finally(() => setInstancesLoading(false));
   }, []);
+
+  useEffect(() => {
+    onInstanceChange(instanceChoice === '' || instanceChoice === 'all' ? undefined : Number(instanceChoice));
+  }, [instanceChoice, onInstanceChange]);
 
   useEffect(() => {
     if (instanceChoice === '') {
@@ -248,14 +285,14 @@ export default function AlertsPage() {
 
   return (
     <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="space-y-5">
-      {/* Header */}
-      <div className="flex items-center justify-between flex-wrap gap-4">
-        <div>
-          <h1 className="text-2xl font-bold text-white">Alerts & Errors</h1>
-          <p className="text-xs text-gray-500 mt-1">Collection errors and failed jobs · newest first · auto-refresh 30s</p>
+        {/* Header */}
+        <div className="flex items-center justify-between flex-wrap gap-4">
+          <div>
+            <h1 className="text-2xl font-bold text-white">Alerts & Errors</h1>
+            <p className="text-xs text-gray-500 mt-1">Collection errors and failed jobs · newest first · auto-refresh 30s</p>
+          </div>
+          {instanceSelector}
         </div>
-        {instanceSelector}
-      </div>
 
       {monitoringStoppedBanner}
 


### PR DESCRIPTION
The Alerts page only showed a synthetic feed built from CollectionErrorLog and JobHistory - it never read DBA Dash's actual alert engine, so there was nothing to acknowledge or close. Add a "DBA Dash Alerts" tab backed by the real Alert.ActiveAlerts / Alert.ClosedAlerts tables, with the existing feed kept as a second "Collection Errors & Failed Jobs" tab.

- New /api/alerts/active, /api/alerts/closed, /api/alerts/acknowledge, /api/alerts/close, and /api/alerts/{id}/notes endpoints, all writing through DBA Dash's own stored procedures (Alert.ActiveAlertsAck_Upd, Alert.ClosedAlerts_Add, Alert.Alerts_Notes_Upd) rather than direct table writes, using table-valued parameters for bulk acknowledge/close.
- Gracefully reports "requires DBA Dash 3.17.0+" instead of a generic error when the Alert schema doesn't exist on older repositories.
- New OperatorOrAdmin policy - Viewers can read alerts but not acknowledge/close/annotate them.
- DbaDashAlertsPanel component: active/history toggle, per-row and bulk acknowledge/close, notes editor, priority-based severity badges.
- Unit tests for the alert-schema-missing detection and the table-valued parameter builders (including a real bug caught only by testing against a live SQL Server: SqlClient rejects an empty IEnumerable<SqlDataRecord> for a structured parameter and needs null instead for a zero-row table-valued parameter).

## Description

<!-- What does this PR do? Why? -->

## Type of Change

- [ ] Bug fix
- [X] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: ___

## Checklist

- [X] `npm run build` passes (frontend)
- [X] `dotnet build` passes (backend)
- [X] Tested in browser (dark theme)
- [X] No new TypeScript errors
- [X] SQL queries use parameterized `@param` (no string concat)

## Screenshots

<!-- If applicable, add screenshots of the change -->
<img width="2245" height="412" alt="image" src="https://github.com/user-attachments/assets/4b445742-8d0a-497f-b912-c4e224406e24" />
<img width="2251" height="381" alt="image" src="https://github.com/user-attachments/assets/2092098c-1002-4287-8cc4-65a2ec1160e1" />
