### PR TITLE
Add per-instance/per-tag threshold overrides (#100)

### DIFF
--- a/backend.tests/ThresholdSettingsStoreTests.cs
+++ b/backend.tests/ThresholdSettingsStoreTests.cs
@@ -9,13 +9,8 @@ public sealed class ThresholdSettingsStoreTests
     [Fact]
     public async Task SaveAsync_PersistsThresholds_WithSanitizedValues()
     {
-        var tempRoot = Path.Combine(Path.GetTempPath(), "dbadashwebview-threshold-tests", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(tempRoot);
-        var thresholdPath = Path.Combine(tempRoot, "thresholds.json");
-
-        try
+        await WithTempStore(async store =>
         {
-            var store = new ThresholdSettingsStore(thresholdPath);
             await store.SaveAsync(new Dictionary<string, ThresholdValue>
             {
                 ["cpu"] = new(-5, 90),
@@ -28,6 +23,116 @@ public sealed class ThresholdSettingsStoreTests
             Assert.Equal(90, saved["cpu"].Critical);
             Assert.Equal(10, saved["waits"].Warning);
             Assert.Equal(25, saved["waits"].Critical);
+        });
+    }
+
+    [Fact]
+    public async Task SaveOverridesAsync_PersistsOverrides_WithSanitizedValues()
+    {
+        await WithTempStore(async store =>
+        {
+            await store.SaveOverridesAsync(
+            [
+                new ThresholdOverride("avgCPU", "instance", 7, -5, 95),
+                new ThresholdOverride("avgCPU", "TAG", 3, 20, 40)
+            ]);
+
+            var saved = await store.GetOverridesAsync();
+
+            Assert.Equal(2, saved.Count);
+            var instanceOverride = Assert.Single(saved, o => o.ScopeType == "instance");
+            Assert.Equal(7, instanceOverride.ScopeId);
+            Assert.Equal(0, instanceOverride.Warning);
+            Assert.Equal(95, instanceOverride.Critical);
+
+            var tagOverride = Assert.Single(saved, o => o.ScopeType == "tag");
+            Assert.Equal(3, tagOverride.ScopeId);
+        });
+    }
+
+    [Fact]
+    public async Task SaveOverridesAsync_DropsInvalidEntries()
+    {
+        await WithTempStore(async store =>
+        {
+            await store.SaveOverridesAsync(
+            [
+                new ThresholdOverride("avgCPU", "instance", 0, 10, 20), // non-positive scope id
+                new ThresholdOverride("", "instance", 1, 10, 20), // empty metric key
+                new ThresholdOverride("avgCPU", "group", 1, 10, 20), // unrecognised scope type
+                new ThresholdOverride("avgCPU", "instance", 1, 10, 20) // valid
+            ]);
+
+            var saved = await store.GetOverridesAsync();
+
+            var kept = Assert.Single(saved);
+            Assert.Equal("avgCPU", kept.MetricKey);
+            Assert.Equal(1, kept.ScopeId);
+        });
+    }
+
+    [Fact]
+    public async Task SaveOverridesAsync_DuplicateScopeAndMetric_LastOneWins()
+    {
+        await WithTempStore(async store =>
+        {
+            await store.SaveOverridesAsync(
+            [
+                new ThresholdOverride("avgCPU", "instance", 1, 10, 20),
+                new ThresholdOverride("avgCPU", "instance", 1, 30, 40)
+            ]);
+
+            var saved = await store.GetOverridesAsync();
+
+            var kept = Assert.Single(saved);
+            Assert.Equal(30, kept.Warning);
+            Assert.Equal(40, kept.Critical);
+        });
+    }
+
+    [Fact]
+    public async Task SaveAsync_AndSaveOverridesAsync_DoNotClobberEachOther()
+    {
+        await WithTempStore(async store =>
+        {
+            await store.SaveAsync(new Dictionary<string, ThresholdValue> { ["cpu"] = new(10, 90) });
+            await store.SaveOverridesAsync([new ThresholdOverride("cpu", "instance", 1, 5, 95)]);
+            await store.SaveAsync(new Dictionary<string, ThresholdValue> { ["cpu"] = new(15, 85) });
+
+            var (global, overrides) = await store.GetSettingsAsync();
+
+            Assert.Equal(15, global["cpu"].Warning);
+            Assert.Single(overrides);
+        });
+    }
+
+    [Fact]
+    public async Task GetAsync_MigratesLegacyFlatDictionaryFile()
+    {
+        await WithTempStore(async (store, path) =>
+        {
+            await File.WriteAllTextAsync(path, """{ "cpu": { "warning": 10, "critical": 90 } }""");
+
+            var (global, overrides) = await store.GetSettingsAsync();
+
+            Assert.Equal(10, global["cpu"].Warning);
+            Assert.Equal(90, global["cpu"].Critical);
+            Assert.Empty(overrides);
+        });
+    }
+
+    private static async Task WithTempStore(Func<ThresholdSettingsStore, Task> test) =>
+        await WithTempStore((store, _) => test(store));
+
+    private static async Task WithTempStore(Func<ThresholdSettingsStore, string, Task> test)
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), "dbadashwebview-threshold-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(tempRoot);
+        var thresholdPath = Path.Combine(tempRoot, "thresholds.json");
+
+        try
+        {
+            await test(new ThresholdSettingsStore(thresholdPath), thresholdPath);
         }
         finally
         {

--- a/backend/Auth/AuthContracts.cs
+++ b/backend/Auth/AuthContracts.cs
@@ -88,3 +88,13 @@ public sealed record AdLoginTestResponse(
 public sealed record ThresholdValue(double Warning, double Critical);
 
 public sealed record ThresholdUpdateRequest(Dictionary<string, ThresholdValue> Thresholds);
+
+/// <summary>
+/// A threshold that overrides the global default for a single metric, scoped to
+/// either one instance (<c>ScopeType == "instance"</c>) or every instance carrying
+/// a given DBA Dash tag (<c>ScopeType == "tag"</c>). <see cref="ScopeId"/> is the
+/// InstanceID or TagID respectively.
+/// </summary>
+public sealed record ThresholdOverride(string MetricKey, string ScopeType, int ScopeId, double Warning, double Critical);
+
+public sealed record ThresholdOverridesUpdateRequest(List<ThresholdOverride> Overrides);

--- a/backend/Endpoints/AuthSettingsEndpointMappings.cs
+++ b/backend/Endpoints/AuthSettingsEndpointMappings.cs
@@ -1,4 +1,6 @@
+using System.Security.Claims;
 using DBADashWebView.Auth;
+using DBADashWebView.Data;
 using DBADashWebView.Settings;
 
 namespace DBADashWebView.Endpoints;
@@ -143,8 +145,10 @@ public static class AuthSettingsEndpointMappings
         }).RequireAuthorization(AppPolicies.AdminOnly);
 
         endpoints.MapGet("/api/settings/thresholds", async (ThresholdSettingsStore thresholds, CancellationToken cancellationToken) =>
-            Results.Ok(new { thresholds = await thresholds.GetAsync(cancellationToken) }))
-            .RequireAuthorization();
+        {
+            var (global, overrides) = await thresholds.GetSettingsAsync(cancellationToken);
+            return Results.Ok(new { thresholds = global, overrides });
+        }).RequireAuthorization();
 
         endpoints.MapPost("/api/settings/thresholds", async (
             ThresholdUpdateRequest request,
@@ -154,6 +158,66 @@ public static class AuthSettingsEndpointMappings
             await thresholds.SaveAsync(request.Thresholds, cancellationToken);
             return Results.Ok(new { success = true });
         }).RequireAuthorization(AppPolicies.AdminOnly);
+
+        // Per-instance/per-tag threshold overrides: the global thresholds above stay
+        // the fallback, but a warning/critical pair here for a more specific scope
+        // (one instance, or every instance carrying a tag) wins over it.
+        endpoints.MapPost("/api/settings/thresholds/overrides", async (
+            ThresholdOverridesUpdateRequest request,
+            ThresholdSettingsStore thresholds,
+            CancellationToken cancellationToken) =>
+        {
+            await thresholds.SaveOverridesAsync(request.Overrides, cancellationToken);
+            return Results.Ok(new { success = true });
+        }).RequireAuthorization(AppPolicies.AdminOnly);
+
+        // Tag options for the override scope picker, and the tag/instance membership
+        // the dashboard needs to resolve tag-scoped overrides client-side. Any
+        // authenticated user can read this (not just admins) since color-coding on
+        // the dashboard depends on it for every role; only saving overrides is
+        // admin-gated above. Kept separate from a general "list tags" endpoint so
+        // this feature doesn't depend on one existing yet.
+        endpoints.MapGet("/api/settings/thresholds/tags", async (ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var (scopeSnippet, scopeParameters) = user.ScopedInstanceFilter("IT.InstanceID");
+                var rows = await sql.QueryAsync(
+                    $"""
+                    SELECT T.TagID, T.TagName, T.TagValue, IT.InstanceID
+                    FROM dbo.Tags T
+                    JOIN dbo.InstanceIDsTags IT ON T.TagID = IT.TagID
+                    JOIN dbo.Instances I ON IT.InstanceID = I.InstanceID
+                    WHERE I.IsActive = 1
+                      {scopeSnippet}
+                    ORDER BY T.TagName, T.TagValue
+                    """,
+                    cancellationToken, scopeParameters);
+
+                var tags = rows
+                    .GroupBy(row => Convert.ToInt32(row["TagID"]))
+                    .Select(group =>
+                    {
+                        var first = group.First();
+                        var tagName = (string)first["TagName"]!;
+                        return new
+                        {
+                            tagId = group.Key,
+                            tagName,
+                            tagValue = first["TagValue"] as string,
+                            isSystem = tagName.StartsWith('{'),
+                            instanceIds = group.Select(row => Convert.ToInt32(row["InstanceID"])).Distinct().ToArray()
+                        };
+                    })
+                    .ToList();
+
+                return Results.Ok(new { data = tags });
+            }
+            catch (Exception ex)
+            {
+                return Results.Ok(new { error = ex.Message, data = Array.Empty<object>() });
+            }
+        }).RequireAuthorization();
 
         return endpoints;
     }

--- a/backend/Settings/ThresholdSettingsStore.cs
+++ b/backend/Settings/ThresholdSettingsStore.cs
@@ -5,6 +5,9 @@ namespace DBADashWebView.Settings;
 
 public sealed class ThresholdSettingsStore
 {
+    private const string InstanceScope = "instance";
+    private const string TagScope = "tag";
+
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
@@ -19,19 +22,20 @@ public sealed class ThresholdSettingsStore
         _path = path ?? Path.Combine(AppContext.BaseDirectory, "config", "thresholds.json");
     }
 
-    public async Task<Dictionary<string, ThresholdValue>> GetAsync(CancellationToken cancellationToken = default)
+    public async Task<Dictionary<string, ThresholdValue>> GetAsync(CancellationToken cancellationToken = default) =>
+        (await GetSettingsAsync(cancellationToken)).Global;
+
+    public async Task<List<ThresholdOverride>> GetOverridesAsync(CancellationToken cancellationToken = default) =>
+        (await GetSettingsAsync(cancellationToken)).Overrides;
+
+    public async Task<(Dictionary<string, ThresholdValue> Global, List<ThresholdOverride> Overrides)> GetSettingsAsync(
+        CancellationToken cancellationToken = default)
     {
         await _mutex.WaitAsync(cancellationToken);
         try
         {
-            if (!File.Exists(_path))
-            {
-                return [];
-            }
-
-            await using var stream = File.OpenRead(_path);
-            return await JsonSerializer.DeserializeAsync<Dictionary<string, ThresholdValue>>(stream, JsonOptions, cancellationToken)
-                ?? [];
+            var file = await ReadFileAsync(cancellationToken);
+            return (file.Global, file.Overrides);
         }
         finally
         {
@@ -41,24 +45,113 @@ public sealed class ThresholdSettingsStore
 
     public async Task SaveAsync(IDictionary<string, ThresholdValue> thresholds, CancellationToken cancellationToken = default)
     {
-        var sanitized = thresholds
-            .Where(entry => !string.IsNullOrWhiteSpace(entry.Key))
-            .ToDictionary(
-                entry => entry.Key.Trim(),
-                entry => new ThresholdValue(
-                    Math.Max(0, entry.Value.Warning),
-                    Math.Max(0, entry.Value.Critical)));
+        var sanitized = SanitizeGlobal(thresholds);
 
         await _mutex.WaitAsync(cancellationToken);
         try
         {
-            Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
-            await using var stream = File.Create(_path);
-            await JsonSerializer.SerializeAsync(stream, sanitized, JsonOptions, cancellationToken);
+            var file = await ReadFileAsync(cancellationToken);
+            await WriteFileAsync(file with { Global = sanitized }, cancellationToken);
         }
         finally
         {
             _mutex.Release();
         }
     }
+
+    /// <summary>
+    /// Replaces the full set of per-instance/per-tag overrides. Like <see cref="SaveAsync"/>,
+    /// the caller is expected to send the complete desired list each time.
+    /// </summary>
+    public async Task SaveOverridesAsync(IEnumerable<ThresholdOverride> overrides, CancellationToken cancellationToken = default)
+    {
+        var sanitized = SanitizeOverrides(overrides);
+
+        await _mutex.WaitAsync(cancellationToken);
+        try
+        {
+            var file = await ReadFileAsync(cancellationToken);
+            await WriteFileAsync(file with { Overrides = sanitized }, cancellationToken);
+        }
+        finally
+        {
+            _mutex.Release();
+        }
+    }
+
+    private static Dictionary<string, ThresholdValue> SanitizeGlobal(IDictionary<string, ThresholdValue> thresholds) =>
+        thresholds
+            .Where(entry => !string.IsNullOrWhiteSpace(entry.Key))
+            .ToDictionary(
+                entry => entry.Key.Trim(),
+                entry => new ThresholdValue(Math.Max(0, entry.Value.Warning), Math.Max(0, entry.Value.Critical)));
+
+    /// <summary>
+    /// Drops overrides with no metric key, an unrecognised scope type, or a
+    /// non-positive scope id, clamps warning/critical to non-negative, and
+    /// collapses duplicates for the same (scope, metric) to the last one supplied.
+    /// </summary>
+    private static List<ThresholdOverride> SanitizeOverrides(IEnumerable<ThresholdOverride> overrides)
+    {
+        var byKey = new Dictionary<(string ScopeType, int ScopeId, string MetricKey), ThresholdOverride>();
+        foreach (var entry in overrides)
+        {
+            if (entry is null || string.IsNullOrWhiteSpace(entry.MetricKey) || entry.ScopeId <= 0)
+            {
+                continue;
+            }
+
+            var scopeType = entry.ScopeType?.Trim().ToLowerInvariant();
+            if (scopeType != InstanceScope && scopeType != TagScope)
+            {
+                continue;
+            }
+
+            var metricKey = entry.MetricKey.Trim();
+            byKey[(scopeType, entry.ScopeId, metricKey)] = new ThresholdOverride(
+                metricKey, scopeType, entry.ScopeId, Math.Max(0, entry.Warning), Math.Max(0, entry.Critical));
+        }
+
+        return byKey.Values.ToList();
+    }
+
+    private async Task<ThresholdSettingsFile> ReadFileAsync(CancellationToken cancellationToken)
+    {
+        if (!File.Exists(_path))
+        {
+            return new ThresholdSettingsFile([], []);
+        }
+
+        var json = await File.ReadAllTextAsync(_path, cancellationToken);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new ThresholdSettingsFile([], []);
+        }
+
+        var parsed = JsonSerializer.Deserialize<ThresholdSettingsFileDto>(json, JsonOptions);
+        if (parsed?.Global is not null)
+        {
+            return new ThresholdSettingsFile(parsed.Global, parsed.Overrides ?? []);
+        }
+
+        // Legacy format written before overrides existed: a flat
+        // { metricKey: { warning, critical } } dictionary with no wrapper object.
+        var legacy = JsonSerializer.Deserialize<Dictionary<string, ThresholdValue>>(json, JsonOptions) ?? [];
+        return new ThresholdSettingsFile(legacy, []);
+    }
+
+    private async Task WriteFileAsync(ThresholdSettingsFile file, CancellationToken cancellationToken)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_path)!);
+        await using var stream = File.Create(_path);
+        await JsonSerializer.SerializeAsync(
+            stream,
+            new ThresholdSettingsFileDto(file.Global, file.Overrides),
+            JsonOptions,
+            cancellationToken);
+    }
+
+    private sealed record ThresholdSettingsFile(Dictionary<string, ThresholdValue> Global, List<ThresholdOverride> Overrides);
+
+    private sealed record ThresholdSettingsFileDto(Dictionary<string, ThresholdValue>? Global, List<ThresholdOverride>? Overrides);
 }

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -47,6 +47,9 @@ import type {
   SlowQueryRow,
   TempDbFileRow,
   ThresholdMap,
+  ThresholdOverride,
+  ThresholdScopeTagOption,
+  ThresholdSettingsResponse,
   TreeInstanceNode,
   UnderutilizedReportRow,
   UpdateLocalUserRequest,
@@ -111,7 +114,7 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 }
 
 export { isAuthenticated, setAuthSession };
-export type { ThresholdMap } from './types';
+export type { ThresholdMap, ThresholdOverride, ThresholdScopeTagOption, ThresholdSettingsResponse } from './types';
 
 export const api = {
   authStatus: () => request<AuthStatusResponse>('/api/auth/status'),
@@ -208,9 +211,13 @@ export const api = {
   reportsBackupAmpel: () => request<BackupAmpelResponse>('/api/reports/backup-ampel'),
   dashboardMonitor: () => request<DashboardMonitorResponse>('/api/dashboard/monitor'),
   getThresholds: () =>
-    request<{ thresholds: ThresholdMap }>('/api/settings/thresholds'),
+    request<ThresholdSettingsResponse>('/api/settings/thresholds'),
   saveThresholds: (thresholds: ThresholdMap) =>
     request<{ success: boolean }>('/api/settings/thresholds', { method: 'POST', body: JSON.stringify({ thresholds }) }),
+  saveThresholdOverrides: (overrides: ThresholdOverride[]) =>
+    request<{ success: boolean }>('/api/settings/thresholds/overrides', { method: 'POST', body: JSON.stringify({ overrides }) }),
+  getThresholdScopeTags: () =>
+    request<{ data: ThresholdScopeTagOption[] }>('/api/settings/thresholds/tags'),
   getAdConfig: async () => {
     const response = await request<AdConfig>('/api/settings/ad');
     return { ...response, bindPassword: '' };

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -495,6 +495,29 @@ export interface ThresholdValue {
 
 export type ThresholdMap = Record<string, ThresholdValue>;
 
+export type ThresholdScopeType = 'instance' | 'tag';
+
+export interface ThresholdOverride {
+  metricKey: string;
+  scopeType: ThresholdScopeType;
+  scopeId: number;
+  warning: number;
+  critical: number;
+}
+
+export interface ThresholdSettingsResponse {
+  thresholds: ThresholdMap;
+  overrides: ThresholdOverride[];
+}
+
+export interface ThresholdScopeTagOption {
+  tagId: number;
+  tagName: string;
+  tagValue: string | null;
+  isSystem: boolean;
+  instanceIds: number[];
+}
+
 export interface SearchInstanceRow extends ApiRow {
   InstanceID: number;
   InstanceDisplayName?: string;

--- a/frontend/src/pages/DashboardPerfSummary.tsx
+++ b/frontend/src/pages/DashboardPerfSummary.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { api } from '../api/api';
-import type { DashboardPerformanceRow, ThresholdMap } from '../api/types';
+import type { DashboardPerformanceRow, ThresholdMap, ThresholdOverride } from '../api/types';
 import { RefreshCw, ArrowUpDown, ArrowUp, ArrowDown, Clock, Loader2 } from 'lucide-react';
 
 type SortDir = 'asc' | 'desc';
@@ -24,8 +24,44 @@ const columns = [
 
 type DashboardPerformanceColumnKey = typeof columns[number]['key'];
 
-function getCellClass(key: string, value: number, thresholds: ThresholdMap): string {
-  const threshold = thresholds[key];
+/**
+ * Most-specific-wins: an override scoped to this exact instance beats one scoped
+ * to a tag the instance carries, which beats the global default. When an
+ * instance carries multiple tags with conflicting overrides for the same
+ * metric, the most sensitive (lowest critical) one wins so nothing gets missed.
+ */
+function resolveThreshold(
+  metricKey: string,
+  instanceId: number,
+  thresholds: ThresholdMap,
+  overrides: ThresholdOverride[],
+  instanceTagIds: Map<number, number[]>
+): ThresholdMap[string] | null {
+  const instanceOverride = overrides.find(
+    (o) => o.scopeType === 'instance' && o.scopeId === instanceId && o.metricKey === metricKey
+  );
+  if (instanceOverride) return instanceOverride;
+
+  const tagIds = instanceTagIds.get(instanceId) || [];
+  const tagOverrides = overrides.filter(
+    (o) => o.scopeType === 'tag' && o.metricKey === metricKey && tagIds.includes(o.scopeId)
+  );
+  if (tagOverrides.length > 0) {
+    return tagOverrides.reduce((most, current) => (current.critical < most.critical ? current : most));
+  }
+
+  return thresholds[metricKey] || null;
+}
+
+function getCellClass(
+  key: string,
+  value: number,
+  instanceId: number,
+  thresholds: ThresholdMap,
+  overrides: ThresholdOverride[],
+  instanceTagIds: Map<number, number[]>
+): string {
+  const threshold = resolveThreshold(key, instanceId, thresholds, overrides, instanceTagIds);
   if (!threshold) return '';
   if (value >= threshold.critical) return 'bg-red-900/50 text-red-300';
   if (value >= threshold.warning) return 'bg-amber-900/50 text-amber-300';
@@ -42,6 +78,8 @@ function formatNum(value: unknown): string {
 export default function DashboardPerfSummary() {
   const [data, setData] = useState<DashboardPerformanceRow[]>([]);
   const [thresholds, setThresholds] = useState<ThresholdMap>({});
+  const [overrides, setOverrides] = useState<ThresholdOverride[]>([]);
+  const [instanceTagIds, setInstanceTagIds] = useState<Map<number, number[]>>(new Map());
   const [loading, setLoading] = useState(true);
   const [sortKey, setSortKey] = useState<DashboardPerformanceColumnKey>('maxCPU');
   const [sortDir, setSortDir] = useState<SortDir>('desc');
@@ -51,9 +89,10 @@ export default function DashboardPerfSummary() {
 
   const fetchData = useCallback(async () => {
     try {
-      const [perfRes, thresholdRes] = await Promise.all([
+      const [perfRes, thresholdRes, tagsRes] = await Promise.all([
         api.dashboardPerformanceSummary().catch(() => ({ data: [], note: '' })),
-        api.getThresholds().catch(() => ({ thresholds: {} })),
+        api.getThresholds().catch(() => ({ thresholds: {}, overrides: [] })),
+        api.getThresholdScopeTags().catch(() => ({ data: [] })),
       ]);
       const incoming = Array.isArray(perfRes.data) ? perfRes.data : [];
       setData((previous) => {
@@ -78,6 +117,16 @@ export default function DashboardPerfSummary() {
         return changed ? merged : previous;
       });
       setThresholds(thresholdRes.thresholds || {});
+      setOverrides(thresholdRes.overrides || []);
+      const tagMap = new Map<number, number[]>();
+      for (const tag of tagsRes.data || []) {
+        for (const instanceId of tag.instanceIds) {
+          const existing = tagMap.get(instanceId);
+          if (existing) existing.push(tag.tagId);
+          else tagMap.set(instanceId, [tag.tagId]);
+        }
+      }
+      setInstanceTagIds(tagMap);
       setLastRefresh(new Date());
     } finally {
       setLoading(false);
@@ -182,7 +231,7 @@ export default function DashboardPerfSummary() {
                     }
                     const value = Number(row[column.key]) || 0;
                     return (
-                      <td key={column.key} className={`py-2 px-3 text-right font-mono whitespace-nowrap ${getCellClass(column.key, value, thresholds)}`}>
+                      <td key={column.key} className={`py-2 px-3 text-right font-mono whitespace-nowrap ${getCellClass(column.key, value, row.instanceID, thresholds, overrides, instanceTagIds)}`}>
                         {formatNum(value)}
                       </td>
                     );

--- a/frontend/src/pages/ThresholdsPage.tsx
+++ b/frontend/src/pages/ThresholdsPage.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { api } from '../api/api';
-import type { ThresholdMap } from '../api/api';
-import { Settings, Save } from 'lucide-react';
+import type { InstanceListRow, ThresholdMap, ThresholdOverride, ThresholdScopeTagOption, ThresholdScopeType } from '../api/types';
+import { Settings, Save, Plus, Trash2 } from 'lucide-react';
 
 const metrics = [
   { key: 'avgCPU', label: 'Avg CPU %' },
@@ -18,16 +18,55 @@ const metrics = [
   { key: 'iOPs', label: 'IOPs' },
 ];
 
+function metricLabel(key: string): string {
+  return metrics.find((m) => m.key === key)?.label || key;
+}
+
 export default function ThresholdsPage() {
   const [thresholds, setThresholds] = useState<ThresholdMap>({});
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<{ msg: string; ok: boolean } | null>(null);
 
+  const [overrides, setOverrides] = useState<ThresholdOverride[]>([]);
+  const [instances, setInstances] = useState<InstanceListRow[]>([]);
+  const [tags, setTags] = useState<ThresholdScopeTagOption[]>([]);
+  const [savingOverride, setSavingOverride] = useState(false);
+
+  const [newScopeType, setNewScopeType] = useState<ThresholdScopeType>('instance');
+  const [newScopeId, setNewScopeId] = useState('');
+  const [newMetric, setNewMetric] = useState(metrics[0].key);
+  const [newWarning, setNewWarning] = useState('');
+  const [newCritical, setNewCritical] = useState('');
+
   useEffect(() => {
     api.getThresholds().then(res => {
       if (res.thresholds) setThresholds(res.thresholds);
+      if (Array.isArray(res.overrides)) setOverrides(res.overrides);
     }).catch(() => {});
+    api.instances().then(res => setInstances(Array.isArray(res) ? res : [])).catch(() => {});
+    api.getThresholdScopeTags().then(res => setTags(Array.isArray(res.data) ? res.data : [])).catch(() => {});
   }, []);
+
+  const instanceName = useMemo(() => {
+    const byId = new Map(instances.map(i => [i.InstanceID, i.InstanceDisplayName || i.Instance || `Instance #${i.InstanceID}`]));
+    return (id: number) => byId.get(id) || `Instance #${id}`;
+  }, [instances]);
+
+  const tagName = useMemo(() => {
+    const byId = new Map(tags.map(t => [t.tagId, t.tagValue ? `${t.tagName}: ${t.tagValue}` : t.tagName]));
+    return (id: number) => byId.get(id) || `Tag #${id}`;
+  }, [tags]);
+
+  const scopeOptions = newScopeType === 'instance'
+    ? instances.map(i => ({ value: i.InstanceID, label: i.InstanceDisplayName || i.Instance || `Instance #${i.InstanceID}` }))
+    : tags.map(t => ({ value: t.tagId, label: (t.tagValue ? `${t.tagName}: ${t.tagValue}` : t.tagName) + (t.isSystem ? ' (system)' : '') }));
+
+  const sortedOverrides = [...overrides].sort((a, b) => {
+    if (a.scopeType !== b.scopeType) return a.scopeType.localeCompare(b.scopeType);
+    const nameA = a.scopeType === 'instance' ? instanceName(a.scopeId) : tagName(a.scopeId);
+    const nameB = b.scopeType === 'instance' ? instanceName(b.scopeId) : tagName(b.scopeId);
+    return nameA.localeCompare(nameB) || metricLabel(a.metricKey).localeCompare(metricLabel(b.metricKey));
+  });
 
   const update = (key: string, field: 'warning' | 'critical', value: string) => {
     setThresholds(prev => {
@@ -53,6 +92,54 @@ export default function ThresholdsPage() {
       setSaving(false);
       setTimeout(() => setToast(null), 3000);
     }
+  };
+
+  const persistOverrides = async (updated: ThresholdOverride[]) => {
+    setSavingOverride(true);
+    try {
+      await api.saveThresholdOverrides(updated);
+      setOverrides(updated);
+      return true;
+    } catch (e) {
+      setToast({ msg: `Error: ${e instanceof Error ? e.message : 'Unknown error'}`, ok: false });
+      setTimeout(() => setToast(null), 3000);
+      return false;
+    } finally {
+      setSavingOverride(false);
+    }
+  };
+
+  const handleAddOverride = async () => {
+    if (newScopeId === '') return;
+    const scopeId = Number(newScopeId);
+    if (!Number.isFinite(scopeId) || scopeId <= 0) return;
+
+    const warning = newWarning === '' ? 0 : parseFloat(newWarning);
+    const critical = newCritical === '' ? 0 : parseFloat(newCritical);
+    if ((isNaN(warning) || warning === 0) && (isNaN(critical) || critical === 0)) return;
+
+    const next: ThresholdOverride = {
+      metricKey: newMetric,
+      scopeType: newScopeType,
+      scopeId,
+      warning: isNaN(warning) ? 0 : warning,
+      critical: isNaN(critical) ? 0 : critical,
+    };
+    const withoutDuplicate = overrides.filter(
+      o => !(o.scopeType === next.scopeType && o.scopeId === next.scopeId && o.metricKey === next.metricKey)
+    );
+    const ok = await persistOverrides([...withoutDuplicate, next]);
+    if (ok) {
+      setNewScopeId('');
+      setNewWarning('');
+      setNewCritical('');
+      setToast({ msg: 'Override saved', ok: true });
+      setTimeout(() => setToast(null), 3000);
+    }
+  };
+
+  const handleDeleteOverride = (target: ThresholdOverride) => {
+    persistOverrides(overrides.filter(o => o !== target));
   };
 
   return (
@@ -115,6 +202,94 @@ export default function ThresholdsPage() {
             {saving ? 'Saving...' : 'Save Thresholds'}
           </button>
         </div>
+      </div>
+
+      <div className="glass rounded-xl p-6 space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold text-white">Per-Instance / Per-Tag Overrides</h2>
+          <p className="text-sm text-gray-400 mt-1">
+            Override the global default above for a specific instance, or for every instance carrying a tag.
+            An instance-specific override always wins; a tag-specific override wins over the global default.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-[110px_1fr_1fr_110px_110px_auto] gap-3 items-center">
+          <select
+            value={newScopeType}
+            onChange={e => { setNewScopeType(e.target.value as ThresholdScopeType); setNewScopeId(''); }}
+            className="bg-white/5 border border-white/10 rounded-lg px-2 py-1.5 text-sm text-white focus:outline-none focus:border-blue-500/50"
+          >
+            <option value="instance">Instance</option>
+            <option value="tag">Tag</option>
+          </select>
+          <select
+            value={newScopeId}
+            onChange={e => setNewScopeId(e.target.value)}
+            className="bg-white/5 border border-white/10 rounded-lg px-2 py-1.5 text-sm text-white focus:outline-none focus:border-blue-500/50"
+          >
+            <option value="">
+              {newScopeType === 'instance' ? 'Select instance…' : 'Select tag…'}
+            </option>
+            {scopeOptions.map(opt => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+          <select
+            value={newMetric}
+            onChange={e => setNewMetric(e.target.value)}
+            className="bg-white/5 border border-white/10 rounded-lg px-2 py-1.5 text-sm text-white focus:outline-none focus:border-blue-500/50"
+          >
+            {metrics.map(m => <option key={m.key} value={m.key}>{m.label}</option>)}
+          </select>
+          <input
+            type="number"
+            step="any"
+            value={newWarning}
+            onChange={e => setNewWarning(e.target.value)}
+            placeholder="Warning"
+            className="bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-amber-500/50"
+          />
+          <input
+            type="number"
+            step="any"
+            value={newCritical}
+            onChange={e => setNewCritical(e.target.value)}
+            placeholder="Critical"
+            className="bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-sm text-white placeholder-gray-600 focus:outline-none focus:border-red-500/50"
+          />
+          <button
+            onClick={handleAddOverride}
+            disabled={savingOverride || newScopeId === ''}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-blue-500/20 text-blue-400 rounded-lg text-sm hover:bg-blue-500/30 disabled:opacity-50 transition-colors"
+          >
+            <Plus className="w-4 h-4" /> Add
+          </button>
+        </div>
+
+        {sortedOverrides.length === 0 ? (
+          <p className="text-sm text-gray-500 py-2">No overrides configured.</p>
+        ) : (
+          <div className="divide-y divide-white/5">
+            {sortedOverrides.map((o, index) => (
+              <div key={`${o.scopeType}-${o.scopeId}-${o.metricKey}-${index}`} className="grid grid-cols-[110px_1fr_1fr_110px_110px_auto] gap-3 items-center py-2">
+                <span className="text-xs uppercase tracking-wider text-gray-400">{o.scopeType}</span>
+                <span className="text-sm text-white truncate">
+                  {o.scopeType === 'instance' ? instanceName(o.scopeId) : tagName(o.scopeId)}
+                </span>
+                <span className="text-sm text-gray-300">{metricLabel(o.metricKey)}</span>
+                <span className="text-sm text-amber-300">{o.warning || '--'}</span>
+                <span className="text-sm text-red-300">{o.critical || '--'}</span>
+                <button
+                  onClick={() => handleDeleteOverride(o)}
+                  disabled={savingOverride}
+                  className="p-1.5 rounded hover:bg-red-500/10 text-gray-400 hover:text-red-400 disabled:opacity-50 justify-self-end"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
The Thresholds page only supported a single global warning/critical pair per metric - there was no way to set a stricter or looser threshold for one instance, or for a whole group of instances sharing a tag, without changing the setting for the entire fleet.

- New ThresholdOverride model layered on top of the existing global ThresholdSettingsStore file: an override targets one instance or one tag, and the most specific match wins (instance beats tag beats global; the most sensitive tag override wins when an instance carries several matching tags).
- POST /api/settings/thresholds/overrides (admin-only, full-list replace, same contract style as the existing global save) and GET /api/settings/thresholds/tags for the scope picker, both scoped through the caller's existing tag/instance RBAC.
- Legacy thresholds.json files (the old flat metric->value dictionary) are read transparently as global-only with no overrides, so existing deployments don't need a migration step.
- ThresholdsPage gets an overrides section (add/list/delete, resolved scope names shown instead of raw ids); DashboardPerfSummary now resolves the effective threshold per cell instead of only reading the global map.

## Description

Adds per-instance and per-tag threshold overrides on top of the existing
global dashboard color-coding thresholds. An override can target one
instance or every instance carrying a tag; resolution is most-specific-wins
(instance > tag > global, most sensitive tag override wins on conflict).
Closes #100.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: ___

## Checklist

- [x] `npm run build` passes (frontend)
- [x] `dotnet build` passes (backend)
- [x] Tested in browser (dark theme)
- [x] No new TypeScript errors
- [x] SQL queries use parameterized `@param` (no string concat)

## Screenshots

<!-- If applicable, add screenshots of the change -->
<img width="977" height="287" alt="image" src="https://github.com/user-attachments/assets/2f4f314a-3647-4f64-8c0e-57bf917af567" />
