### PR TITLE
Feature/101 drives filters

### DIFF
--- a/backend.tests/EstateEndpointMappingsTests.cs
+++ b/backend.tests/EstateEndpointMappingsTests.cs
@@ -1,0 +1,53 @@
+using DBADashWebView.Endpoints;
+using Xunit;
+
+namespace DBADashWebView.Tests;
+
+public sealed class EstateEndpointMappingsTests
+{
+    [Fact]
+    public void ParseDriveIds_ParsesAndDedupes()
+    {
+        var ids = EstateEndpointMappings.ParseDriveIds("1,2,2,3, 4");
+
+        Assert.Equal([1, 2, 3, 4], ids);
+    }
+
+    [Fact]
+    public void ParseDriveIds_DropsNonNumericEntries()
+    {
+        var ids = EstateEndpointMappings.ParseDriveIds("1,abc,,3");
+
+        Assert.Equal([1, 3], ids);
+    }
+
+    [Fact]
+    public void ParseDriveIds_NullOrEmpty_ReturnsEmptyList()
+    {
+        Assert.Empty(EstateEndpointMappings.ParseDriveIds(null));
+        Assert.Empty(EstateEndpointMappings.ParseDriveIds(""));
+        Assert.Empty(EstateEndpointMappings.ParseDriveIds("   "));
+    }
+
+    [Fact]
+    public void ParseDriveIds_CapsAtMaxCount()
+    {
+        var raw = string.Join(",", Enumerable.Range(1, 100));
+
+        var ids = EstateEndpointMappings.ParseDriveIds(raw, maxCount: 10);
+
+        Assert.Equal(10, ids.Count);
+        Assert.Equal(Enumerable.Range(1, 10), ids);
+    }
+
+    [Theory]
+    [InlineData(null, 30)]
+    [InlineData(0, 1)]
+    [InlineData(-5, 1)]
+    [InlineData(400, 365)]
+    [InlineData(90, 90)]
+    public void ClampGrowthWindowDays_ClampsToValidRange(int? input, int expected)
+    {
+        Assert.Equal(expected, EstateEndpointMappings.ClampGrowthWindowDays(input));
+    }
+}

--- a/backend/Endpoints/EstateEndpointMappings.cs
+++ b/backend/Endpoints/EstateEndpointMappings.cs
@@ -79,6 +79,75 @@ public static class EstateEndpointMappings
             }
         }).RequireAuthorization();
 
+        // Real growth for a chosen set of drives, backed by dbo.DriveSnapshot (a row
+        // per drive per collection cycle) rather than a guessed/linear projection.
+        // Returns the oldest and newest snapshot within the window per drive; the
+        // caller derives a rate/projection from those two real data points.
+        endpoints.MapGet("/api/drives/growth", async (string? driveIds, int? days, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            var ids = ParseDriveIds(driveIds);
+
+            if (ids.Count == 0)
+            {
+                return Results.Ok(new { data = Array.Empty<object>() });
+            }
+
+            try
+            {
+                var (scopeSnippet, scopeParameters) = user.ScopedInstanceFilter("d.InstanceID");
+                var idParamNames = ids.Select((_, index) => $"@id{index}").ToArray();
+                var idParams = ids.Select((driveId, index) => ($"@id{index}", (object?)driveId)).ToArray();
+                var fromDate = DateTime.UtcNow.AddDays(-ClampGrowthWindowDays(days));
+
+                await using var connection = await sql.OpenConnectionAsync(cancellationToken);
+                await using var command = new SqlCommand(
+                    $"""
+                    WITH bounds AS (
+                        SELECT s.DriveID, s.SnapshotDate, s.Capacity, s.FreeSpace,
+                               ROW_NUMBER() OVER (PARTITION BY s.DriveID ORDER BY s.SnapshotDate ASC) AS rn_asc,
+                               ROW_NUMBER() OVER (PARTITION BY s.DriveID ORDER BY s.SnapshotDate DESC) AS rn_desc,
+                               COUNT(*) OVER (PARTITION BY s.DriveID) AS pointCount
+                        FROM dbo.DriveSnapshot s
+                        JOIN dbo.Drives d ON d.DriveID = s.DriveID
+                        WHERE s.DriveID IN ({string.Join(", ", idParamNames)})
+                          AND s.SnapshotDate >= @fromDate
+                          AND d.IsActive = 1
+                          {scopeSnippet}
+                    )
+                    SELECT DriveID,
+                           MAX(pointCount) AS DataPoints,
+                           MAX(CASE WHEN rn_asc = 1 THEN SnapshotDate END) AS OldestSnapshotDate,
+                           MAX(CASE WHEN rn_asc = 1 THEN FreeSpace END) AS OldestFreeSpace,
+                           MAX(CASE WHEN rn_desc = 1 THEN SnapshotDate END) AS LatestSnapshotDate,
+                           MAX(CASE WHEN rn_desc = 1 THEN FreeSpace END) AS LatestFreeSpace,
+                           MAX(CASE WHEN rn_desc = 1 THEN Capacity END) AS LatestCapacity
+                    FROM bounds
+                    WHERE rn_asc = 1 OR rn_desc = 1
+                    GROUP BY DriveID
+                    """,
+                    connection)
+                {
+                    CommandTimeout = 30
+                };
+                command.Parameters.AddWithValue("@fromDate", fromDate);
+                foreach (var (name, value) in idParams)
+                {
+                    command.Parameters.AddWithValue(name, value ?? DBNull.Value);
+                }
+                foreach (var (name, value) in scopeParameters)
+                {
+                    command.Parameters.AddWithValue(name, value ?? DBNull.Value);
+                }
+
+                var data = await EndpointResultMapper.ReadRowsAsync(command, cancellationToken, camelCase: true);
+                return Results.Ok(new { data });
+            }
+            catch (Exception ex)
+            {
+                return Results.Ok(new { error = ex.Message, data = Array.Empty<object>() });
+            }
+        }).RequireAuthorization();
+
         endpoints.MapGet("/api/tree", async (ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
         {
             try
@@ -145,4 +214,21 @@ public static class EstateEndpointMappings
 
         return endpoints;
     }
+
+    /// <summary>
+    /// Parses a comma-separated list of drive ids from a query string, dropping
+    /// anything non-numeric, deduping, and capping the count so a caller can't
+    /// force an unbounded IN-list.
+    /// </summary>
+    internal static List<int> ParseDriveIds(string? raw, int maxCount = 50) =>
+        (raw ?? string.Empty)
+            .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .Select(s => int.TryParse(s, out var parsed) ? parsed : (int?)null)
+            .Where(v => v.HasValue)
+            .Select(v => v!.Value)
+            .Distinct()
+            .Take(maxCount)
+            .ToList();
+
+    internal static int ClampGrowthWindowDays(int? days) => Math.Clamp(days ?? 30, 1, 365);
 }

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -13,6 +13,7 @@ import type {
   CreateLocalUserRequest,
   DbSpaceRow,
   EstateBackupRow,
+  DriveGrowthPoint,
   EstateDriveRow,
   FleetStatsRow,
   HadrOverviewResponse,
@@ -148,6 +149,8 @@ export const api = {
   instanceHadr: (id: number) => request<InstanceHadrResponse>(`/api/instances/${id}/hadr`),
   hadrOverview: () => request<HadrOverviewResponse>('/api/hadr/overview'),
   drives: () => request<EstateDriveRow[]>('/api/drives'),
+  drivesGrowth: (driveIds: number[], days = 30) =>
+    request<{ data: DriveGrowthPoint[] }>(`/api/drives/growth?driveIds=${driveIds.join(',')}&days=${days}`),
   instanceQueries: (id: number) => request<QueryAnalysisRow[]>(`/api/instances/${id}/queries`),
   backupsEstate: () => request<EstateBackupRow[]>('/api/backups/estate'),
   backupsManagement: () => request<BackupManagementResponse>('/api/backups/management'),

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -326,6 +326,16 @@ export interface EstateDriveRow extends ApiRow {
   InstanceDisplayName?: string | null;
 }
 
+export interface DriveGrowthPoint {
+  driveID: number;
+  dataPoints: number;
+  oldestSnapshotDate: string | null;
+  oldestFreeSpace: number | null;
+  latestSnapshotDate: string | null;
+  latestFreeSpace: number | null;
+  latestCapacity: number | null;
+}
+
 export interface LicenseReportRow extends ApiRow {
   InstanceID: number;
   InstanceName?: string | null;

--- a/frontend/src/components/MultiSelectFilter.test.tsx
+++ b/frontend/src/components/MultiSelectFilter.test.tsx
@@ -1,0 +1,100 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import MultiSelectFilter from './MultiSelectFilter';
+
+/**
+ * The search box used to be cleared by an effect watching `open`, which tripped
+ * react-hooks/set-state-in-effect. It is now cleared by the two user-driven
+ * close paths instead, so these tests pin the behaviour that refactor had to
+ * preserve: whichever way the dropdown is closed, the next open starts with an
+ * empty search and the unfiltered list.
+ */
+
+// The search field only renders above this many options.
+const OPTIONS = ['C:\\', 'D:\\', 'E:\\', 'F:\\', 'G:\\', 'H:\\', 'I:\\', 'J:\\', 'K:\\'];
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      <MultiSelectFilter
+        label="Drives"
+        options={OPTIONS}
+        selected={[]}
+        onChange={() => {}}
+        mode="include"
+        onModeChange={() => {}}
+      />
+    );
+  });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const toggleButton = () => container.querySelector('button')!;
+const searchBox = () => container.querySelector<HTMLInputElement>('input[type="text"], input:not([type])');
+const optionLabels = () => Array.from(container.querySelectorAll('label')).map(l => l.textContent);
+
+function click(el: Element) {
+  act(() => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+}
+
+/** React tracks the input value internally, so set it through the native setter. */
+function type(input: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+  act(() => {
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+function clickOutside() {
+  act(() => {
+    document.body.dispatchEvent(new MouseEvent('mousedown', { bubbles: true }));
+  });
+}
+
+describe('MultiSelectFilter', () => {
+  it('shows a search box once there are more than 8 options', () => {
+    expect(searchBox()).toBeNull();
+    click(toggleButton());
+    expect(searchBox()).not.toBeNull();
+  });
+
+  it('filters the options as you type', () => {
+    click(toggleButton());
+    type(searchBox()!, 'd:');
+    expect(optionLabels()).toEqual(['D:\\']);
+  });
+
+  it('clears the search when closed with the toggle button', () => {
+    click(toggleButton());
+    type(searchBox()!, 'd:');
+    click(toggleButton()); // close
+    click(toggleButton()); // reopen
+
+    expect(searchBox()!.value).toBe('');
+    expect(optionLabels()).toHaveLength(OPTIONS.length);
+  });
+
+  it('clears the search when closed by clicking outside', () => {
+    click(toggleButton());
+    type(searchBox()!, 'd:');
+    clickOutside();
+    click(toggleButton()); // reopen
+
+    expect(searchBox()!.value).toBe('');
+    expect(optionLabels()).toHaveLength(OPTIONS.length);
+  });
+});

--- a/frontend/src/components/MultiSelectFilter.tsx
+++ b/frontend/src/components/MultiSelectFilter.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown, X } from 'lucide-react';
+import { clsx } from 'clsx';
+
+export type FilterMode = 'include' | 'exclude';
+
+interface MultiSelectFilterProps {
+  label: string;
+  options: string[];
+  selected: string[];
+  onChange: (selected: string[]) => void;
+  mode: FilterMode;
+  onModeChange: (mode: FilterMode) => void;
+}
+
+/**
+ * Dropdown checkbox list with an include/exclude toggle, e.g. "show only these
+ * drives" vs "hide these drives". Used anywhere a plain single-select dropdown
+ * isn't enough (drive letters, instance names, ...).
+ */
+export default function MultiSelectFilter({ label, options, selected, onChange, mode, onModeChange }: MultiSelectFilterProps) {
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) setSearch('');
+  }, [open]);
+
+  const filteredOptions = search
+    ? options.filter(o => o.toLowerCase().includes(search.toLowerCase()))
+    : options;
+
+  const toggle = (value: string) => {
+    onChange(selected.includes(value) ? selected.filter(v => v !== value) : [...selected, value]);
+  };
+
+  const summary = selected.length === 0
+    ? `All ${label}`
+    : `${mode === 'exclude' ? 'Excl. ' : ''}${label} (${selected.length})`;
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className={clsx(
+          'flex items-center gap-2 px-3 py-2 rounded-lg text-sm border transition-colors',
+          selected.length > 0
+            ? mode === 'exclude'
+              ? 'bg-red-500/10 border-red-500/30 text-red-300'
+              : 'bg-blue-500/10 border-blue-500/30 text-blue-300'
+            : 'bg-slate-800 border-slate-600 text-gray-300 hover:text-white'
+        )}
+      >
+        {summary}
+        <ChevronDown className="w-3.5 h-3.5" />
+      </button>
+
+      {open && (
+        <div className="absolute z-20 mt-1 w-64 rounded-lg border border-white/10 bg-slate-900 shadow-xl p-2">
+          <div className="flex rounded-md overflow-hidden border border-white/10 mb-2 text-xs">
+            <button
+              onClick={() => onModeChange('include')}
+              className={clsx('flex-1 py-1.5 transition-colors', mode === 'include' ? 'bg-blue-500/20 text-blue-300' : 'text-gray-400 hover:text-white')}
+            >
+              Include
+            </button>
+            <button
+              onClick={() => onModeChange('exclude')}
+              className={clsx('flex-1 py-1.5 transition-colors', mode === 'exclude' ? 'bg-red-500/20 text-red-300' : 'text-gray-400 hover:text-white')}
+            >
+              Exclude
+            </button>
+          </div>
+
+          {options.length > 8 && (
+            <input
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder={`Search ${label.toLowerCase()}...`}
+              className="w-full mb-2 bg-white/5 border border-white/10 rounded px-2 py-1 text-xs text-white placeholder-gray-600 focus:outline-none"
+            />
+          )}
+
+          <div className="max-h-56 overflow-y-auto space-y-0.5">
+            {filteredOptions.length === 0 && (
+              <p className="text-xs text-gray-500 px-1 py-1">No matches</p>
+            )}
+            {filteredOptions.map(opt => (
+              <label key={opt} className="flex items-center gap-2 px-1 py-1 rounded hover:bg-white/5 cursor-pointer text-xs text-gray-200">
+                <input
+                  type="checkbox"
+                  checked={selected.includes(opt)}
+                  onChange={() => toggle(opt)}
+                  className="accent-blue-500"
+                />
+                <span className="truncate">{opt}</span>
+              </label>
+            ))}
+          </div>
+
+          {selected.length > 0 && (
+            <button
+              onClick={() => onChange([])}
+              className="w-full mt-2 flex items-center justify-center gap-1 text-xs text-gray-400 hover:text-white py-1 border-t border-white/5 pt-2"
+            >
+              <X className="w-3 h-3" /> Clear
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/MultiSelectFilter.tsx
+++ b/frontend/src/components/MultiSelectFilter.tsx
@@ -26,14 +26,13 @@ export default function MultiSelectFilter({ label, options, selected, onChange, 
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+        setSearch('');
+      }
     };
     document.addEventListener('mousedown', handler);
     return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
-
-  useEffect(() => {
-    if (!open) setSearch('');
   }, [open]);
 
   const filteredOptions = search
@@ -51,7 +50,10 @@ export default function MultiSelectFilter({ label, options, selected, onChange, 
   return (
     <div className="relative" ref={ref}>
       <button
-        onClick={() => setOpen(o => !o)}
+        onClick={() => {
+          setOpen(o => !o);
+          setSearch('');
+        }}
         className={clsx(
           'flex items-center gap-2 px-3 py-2 rounded-lg text-sm border transition-colors',
           selected.length > 0

--- a/frontend/src/pages/DrivesPage.tsx
+++ b/frontend/src/pages/DrivesPage.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useState, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { api } from '../api/api';
-import type { EstateDriveRow, InstanceDriveRow } from '../api/types';
+import type { DriveGrowthPoint, EstateDriveRow, InstanceDriveRow } from '../api/types';
+import { computeDriveGrowth } from '../utils/driveGrowth';
 import LoadingSpinner from '../components/LoadingSpinner';
 import EmptyState from '../components/EmptyState';
 import CapacityBar from '../components/CapacityBar';
-import { HardDrive, ArrowUpDown, RefreshCw, Filter } from 'lucide-react';
+import MultiSelectFilter, { type FilterMode } from '../components/MultiSelectFilter';
+import { HardDrive, ArrowUpDown, RefreshCw, Filter, Scale, X, Search, TrendingUp, TrendingDown } from 'lucide-react';
 import { motion } from 'framer-motion';
 import { clsx } from 'clsx';
 
@@ -23,13 +25,26 @@ function getUsedPercent(drive: DriveRow): number {
   return ((drive.Capacity - (drive.FreeSpace || 0)) / drive.Capacity) * 100;
 }
 
+function driveKey(drive: DriveRow, index: number): string {
+  return drive.DriveID != null ? `id:${drive.DriveID}` : `pos:${drive.InstanceDisplayName || ''}:${drive.Name || ''}:${index}`;
+}
+
 export default function DrivesPage() {
   const { id } = useParams();
   const [drives, setDrives] = useState<DriveRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [sortDesc, setSortDesc] = useState(true);
-  const [selectedDrive, setSelectedDrive] = useState<string>('');
-  const [selectedInstance, setSelectedInstance] = useState<string>('');
+  const [search, setSearch] = useState('');
+
+  const [driveMode, setDriveMode] = useState<FilterMode>('include');
+  const [selectedDrives, setSelectedDrives] = useState<string[]>([]);
+  const [instanceMode, setInstanceMode] = useState<FilterMode>('include');
+  const [selectedInstances, setSelectedInstances] = useState<string[]>([]);
+
+  const [compareMode, setCompareMode] = useState(false);
+  const [compareKeys, setCompareKeys] = useState<Set<string>>(new Set());
+  const [growthByDriveId, setGrowthByDriveId] = useState<Map<number, DriveGrowthPoint>>(new Map());
+  const [growthLoading, setGrowthLoading] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -57,16 +72,75 @@ export default function DrivesPage() {
   }, [drives, id]);
 
   const filtered = useMemo(() => {
-    return drives.filter(d =>
-      (!selectedDrive || d.Name === selectedDrive) &&
-      (!selectedInstance || d.InstanceDisplayName === selectedInstance)
-    );
-  }, [drives, selectedDrive, selectedInstance]);
+    const q = search.trim().toLowerCase();
+    return drives.filter(d => {
+      if (q) {
+        const matches = (d.Name || '').toLowerCase().includes(q) || (d.InstanceDisplayName || '').toLowerCase().includes(q);
+        if (!matches) return false;
+      }
+
+      if (selectedDrives.length > 0) {
+        const isSelected = selectedDrives.includes(d.Name || '');
+        if (driveMode === 'include' && !isSelected) return false;
+        if (driveMode === 'exclude' && isSelected) return false;
+      }
+
+      if (!id && selectedInstances.length > 0) {
+        const isSelected = selectedInstances.includes(d.InstanceDisplayName || '');
+        if (instanceMode === 'include' && !isSelected) return false;
+        if (instanceMode === 'exclude' && isSelected) return false;
+      }
+
+      return true;
+    });
+  }, [drives, search, selectedDrives, driveMode, selectedInstances, instanceMode, id]);
 
   const sorted = useMemo(() =>
     [...filtered].sort((a, b) =>
       sortDesc ? getUsedPercent(b) - getUsedPercent(a) : getUsedPercent(a) - getUsedPercent(b)
     ), [filtered, sortDesc]);
+
+  const compareDrives = useMemo(
+    () => drives.filter((d, i) => compareKeys.has(driveKey(d, i))),
+    [drives, compareKeys]
+  );
+
+  const compareDriveIds = useMemo(
+    () => [...new Set(compareDrives.map(d => d.DriveID).filter((v): v is number => v != null))].sort(),
+    [compareDrives]
+  );
+
+  useEffect(() => {
+    if (compareDriveIds.length === 0) {
+      setGrowthByDriveId(new Map());
+      return;
+    }
+
+    let cancelled = false;
+    setGrowthLoading(true);
+    api.drivesGrowth(compareDriveIds, 30)
+      .then(res => {
+        if (cancelled) return;
+        const map = new Map<number, DriveGrowthPoint>();
+        for (const point of res.data || []) map.set(point.driveID, point);
+        setGrowthByDriveId(map);
+      })
+      .catch(() => { if (!cancelled) setGrowthByDriveId(new Map()); })
+      .finally(() => { if (!cancelled) setGrowthLoading(false); });
+
+    return () => { cancelled = true; };
+  }, [compareDriveIds]);
+
+  const toggleCompare = (key: string) => {
+    setCompareKeys(prev => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const hasActiveFilters = selectedDrives.length > 0 || selectedInstances.length > 0 || search.trim().length > 0;
 
   if (loading) return <LoadingSpinner />;
 
@@ -76,7 +150,7 @@ export default function DrivesPage() {
   return (
     <div className="space-y-4">
       {/* Header */}
-      <div className="flex items-start justify-between gap-4">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
           <h1 className="text-2xl font-bold text-white">{id ? 'Instance Drives' : 'Drives'}</h1>
           <p className="text-sm text-gray-400 mt-0.5">
@@ -86,31 +160,36 @@ export default function DrivesPage() {
           </p>
         </div>
         <div className="flex items-center gap-2 flex-wrap justify-end">
+          <div className="relative">
+            <Search className="w-3.5 h-3.5 text-gray-500 absolute left-2.5 top-1/2 -translate-y-1/2" />
+            <input
+              value={search}
+              onChange={e => setSearch(e.target.value)}
+              placeholder="Search drive or instance..."
+              className="bg-slate-800 border border-slate-600 rounded-lg pl-8 pr-3 py-2 text-sm text-white placeholder-gray-500 w-56 focus:outline-none"
+            />
+          </div>
           {/* Instance filter (estate view only) */}
           {!id && instanceNames.length > 0 && (
-            <select
-              value={selectedInstance}
-              onChange={e => setSelectedInstance(e.target.value)}
-              className="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-gray-300 focus:outline-none"
-            >
-              <option value="">All Instances</option>
-              {instanceNames.map(name => (
-                <option key={name} value={name}>{name}</option>
-              ))}
-            </select>
+            <MultiSelectFilter
+              label="Instances"
+              options={instanceNames}
+              selected={selectedInstances}
+              onChange={setSelectedInstances}
+              mode={instanceMode}
+              onModeChange={setInstanceMode}
+            />
           )}
           {/* Drive name filter */}
           {driveNames.length > 1 && (
-            <select
-              value={selectedDrive}
-              onChange={e => setSelectedDrive(e.target.value)}
-              className="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-gray-300 focus:outline-none"
-            >
-              <option value="">All Drives</option>
-              {driveNames.map(name => (
-                <option key={name} value={name}>{name}</option>
-              ))}
-            </select>
+            <MultiSelectFilter
+              label="Drives"
+              options={driveNames}
+              selected={selectedDrives}
+              onChange={setSelectedDrives}
+              mode={driveMode}
+              onModeChange={setDriveMode}
+            />
           )}
           <button
             onClick={() => setSortDesc(!sortDesc)}
@@ -119,6 +198,19 @@ export default function DrivesPage() {
             <ArrowUpDown className="w-4 h-4" />
             {sortDesc ? 'Most used first' : 'Least used first'}
           </button>
+          <button
+            onClick={() => {
+              setCompareMode(m => !m);
+              if (compareMode) setCompareKeys(new Set());
+            }}
+            className={clsx(
+              'flex items-center gap-2 px-3 py-2 rounded-lg text-sm border transition-colors',
+              compareMode ? 'bg-purple-500/10 border-purple-500/30 text-purple-300' : 'bg-slate-800 border-slate-600 text-gray-300 hover:text-white'
+            )}
+          >
+            <Scale className="w-4 h-4" />
+            {compareMode ? 'Exit Compare' : 'Compare'}
+          </button>
           <span className="text-xs text-gray-500 flex items-center gap-1">
             <RefreshCw className="w-3 h-3" /> Auto-refresh 30s
           </span>
@@ -126,22 +218,104 @@ export default function DrivesPage() {
       </div>
 
       {/* Active filters badge */}
-      {(selectedDrive || selectedInstance) && (
-        <div className="flex items-center gap-2 text-xs text-gray-400">
+      {hasActiveFilters && (
+        <div className="flex items-center gap-2 text-xs text-gray-400 flex-wrap">
           <Filter className="w-3 h-3" />
           <span>Filtering by:</span>
-          {selectedInstance && (
-            <span className="px-2 py-0.5 rounded-full bg-blue-400/10 text-blue-400">
-              {selectedInstance}
-              <button onClick={() => setSelectedInstance('')} className="ml-1 hover:text-white">×</button>
+          {search.trim() && (
+            <span className="px-2 py-0.5 rounded-full bg-slate-500/20 text-gray-300">
+              "{search.trim()}"
+              <button onClick={() => setSearch('')} className="ml-1 hover:text-white">×</button>
             </span>
           )}
-          {selectedDrive && (
-            <span className="px-2 py-0.5 rounded-full bg-purple-400/10 text-purple-400">
-              {selectedDrive}
-              <button onClick={() => setSelectedDrive('')} className="ml-1 hover:text-white">×</button>
+          {selectedInstances.map(name => (
+            <span key={name} className={clsx('px-2 py-0.5 rounded-full', instanceMode === 'exclude' ? 'bg-red-400/10 text-red-400' : 'bg-blue-400/10 text-blue-400')}>
+              {instanceMode === 'exclude' ? 'not ' : ''}{name}
+              <button onClick={() => setSelectedInstances(prev => prev.filter(n => n !== name))} className="ml-1 hover:text-white">×</button>
             </span>
-          )}
+          ))}
+          {selectedDrives.map(name => (
+            <span key={name} className={clsx('px-2 py-0.5 rounded-full', driveMode === 'exclude' ? 'bg-red-400/10 text-red-400' : 'bg-purple-400/10 text-purple-400')}>
+              {driveMode === 'exclude' ? 'not ' : ''}{name}
+              <button onClick={() => setSelectedDrives(prev => prev.filter(n => n !== name))} className="ml-1 hover:text-white">×</button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {compareMode && compareDrives.length > 0 && (
+        <div className="glass rounded-xl p-4 border border-purple-500/20">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-white flex items-center gap-2">
+              <Scale className="w-4 h-4 text-purple-400" /> Comparing {compareDrives.length} drives
+            </h2>
+            <button onClick={() => setCompareKeys(new Set())} className="text-xs text-gray-400 hover:text-white flex items-center gap-1">
+              <X className="w-3 h-3" /> Clear selection
+            </button>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/10 text-left text-xs text-gray-400 uppercase tracking-wider">
+                  <th className="pb-2 pr-4">Drive</th>
+                  {!id && <th className="pb-2 pr-4">Instance</th>}
+                  <th className="pb-2 pr-4 w-40">Usage</th>
+                  <th className="pb-2 pr-4 text-right">Capacity</th>
+                  <th className="pb-2 pr-4 text-right">Used</th>
+                  <th className="pb-2 pr-4 text-right">Free</th>
+                  <th className="pb-2 pr-4 text-right">Used %</th>
+                  <th className="pb-2 text-right">Growth (30d)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {compareDrives.map((d, i) => {
+                  const pct = getUsedPercent(d);
+                  const used = (d.Capacity || 0) - (d.FreeSpace || 0);
+                  const growth = computeDriveGrowth(d.DriveID != null ? growthByDriveId.get(d.DriveID) : undefined);
+                  return (
+                    <tr key={driveKey(d, i)} className="border-b border-white/5">
+                      <td className="py-2 pr-4 text-white font-mono text-xs">{d.Name || d.Label || '—'}</td>
+                      {!id && <td className="py-2 pr-4 text-gray-300">{d.InstanceDisplayName || '—'}</td>}
+                      <td className="py-2 pr-4"><CapacityBar used={used} total={d.Capacity || 0} /></td>
+                      <td className="py-2 pr-4 text-right text-gray-400 text-xs">{formatBytes(d.Capacity)}</td>
+                      <td className="py-2 pr-4 text-right text-gray-400 text-xs">{formatBytes(used)}</td>
+                      <td className="py-2 pr-4 text-right text-gray-400 text-xs">{formatBytes(d.FreeSpace)}</td>
+                      <td className={clsx('py-2 pr-4 text-right text-xs font-semibold', pct >= 85 ? 'text-red-400' : pct >= 70 ? 'text-yellow-400' : 'text-green-400')}>
+                        {pct.toFixed(1)}%
+                      </td>
+                      <td className="py-2 text-right text-xs">
+                        {growthLoading ? (
+                          <span className="text-gray-500">…</span>
+                        ) : growth.bytesPerDay == null ? (
+                          <span className="text-gray-500">not enough history</span>
+                        ) : growth.bytesPerDay <= 0 ? (
+                          <span className="flex items-center justify-end gap-1 text-green-400">
+                            <TrendingDown className="w-3 h-3" /> freeing up
+                          </span>
+                        ) : (
+                          <span className={clsx('flex items-center justify-end gap-1', growth.daysUntilFull != null && growth.daysUntilFull < 30 ? 'text-red-400' : 'text-gray-300')}>
+                            <TrendingUp className="w-3 h-3" />
+                            {formatBytes(growth.bytesPerDay)}/day
+                            {growth.daysUntilFull != null && ` · full in ${Math.round(growth.daysUntilFull)}d`}
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            {compareDriveIds.length > 0 && (
+              <p className="text-xs text-gray-500 mt-2">
+                Growth is measured from real drive-space history (dbo.DriveSnapshot) over the last 30 days, not an estimate.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+      {compareMode && compareDrives.length === 0 && (
+        <div className="glass rounded-xl p-4 border border-purple-500/20 text-sm text-gray-400">
+          Select drives below to compare them side by side.
         </div>
       )}
 
@@ -154,23 +328,38 @@ export default function DrivesPage() {
             const usedBytes = (drive.Capacity || 0) - (drive.FreeSpace || 0);
             const borderColor = pct >= 85 ? 'border-red-500/30' : pct >= 70 ? 'border-yellow-500/30' : 'border-white/5';
             const iconColor = pct >= 85 ? 'text-red-400' : pct >= 70 ? 'text-yellow-400' : 'text-blue-400';
+            const key = driveKey(drive, i);
+            const isCompared = compareKeys.has(key);
             return (
               <motion.div
                 key={drive.DriveID || i}
                 initial={{ opacity: 0, y: 10 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: i * 0.02 }}
-                className={clsx('glass rounded-xl p-5 border', borderColor)}
+                className={clsx('glass rounded-xl p-5 border relative', isCompared ? 'border-purple-500/50 ring-1 ring-purple-500/30' : borderColor)}
               >
+                {compareMode && (
+                  <label className="absolute top-3 right-3 flex items-center">
+                    <input
+                      type="checkbox"
+                      checked={isCompared}
+                      onChange={() => toggleCompare(key)}
+                      className="accent-purple-500 w-4 h-4 cursor-pointer"
+                    />
+                  </label>
+                )}
+
                 {/* Drive header */}
                 <div className="flex items-start gap-3 mb-4">
                   <HardDrive className={clsx('w-5 h-5 mt-0.5 shrink-0', iconColor)} />
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center justify-between gap-2">
                       <p className="text-sm font-semibold text-white truncate">{drive.Name || '—'}</p>
-                      <span className={clsx('text-xs font-bold shrink-0',
-                        pct >= 85 ? 'text-red-400' : pct >= 70 ? 'text-yellow-400' : 'text-green-400'
-                      )}>{pct.toFixed(1)}%</span>
+                      {!compareMode && (
+                        <span className={clsx('text-xs font-bold shrink-0',
+                          pct >= 85 ? 'text-red-400' : pct >= 70 ? 'text-yellow-400' : 'text-green-400'
+                        )}>{pct.toFixed(1)}%</span>
+                      )}
                     </div>
                     {drive.Label && (
                       <p className="text-xs text-gray-500 truncate">{drive.Label}</p>

--- a/frontend/src/pages/DrivesPage.tsx
+++ b/frontend/src/pages/DrivesPage.tsx
@@ -181,7 +181,7 @@ export default function DrivesPage() {
             />
           )}
           {/* Drive name filter */}
-          {driveNames.length > 1 && (
+          {driveNames.length > 0 && (
             <MultiSelectFilter
               label="Drives"
               options={driveNames}

--- a/frontend/src/pages/EstateDiskPage.tsx
+++ b/frontend/src/pages/EstateDiskPage.tsx
@@ -4,7 +4,9 @@ import type { EstateDriveRow } from '../api/types';
 import { useRefresh } from '../App';
 import LoadingSpinner from '../components/LoadingSpinner';
 import CapacityBar from '../components/CapacityBar';
-import { AlertTriangle } from 'lucide-react';
+import MultiSelectFilter, { type FilterMode } from '../components/MultiSelectFilter';
+import { AlertTriangle, Filter } from 'lucide-react';
+import { clsx } from 'clsx';
 
 interface EstateDriveViewModel extends EstateDriveRow {
   capacity: number;
@@ -21,11 +23,26 @@ export default function EstateDiskPage() {
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState('');
 
+  const [driveMode, setDriveMode] = useState<FilterMode>('include');
+  const [selectedDrives, setSelectedDrives] = useState<string[]>([]);
+  const [instanceMode, setInstanceMode] = useState<FilterMode>('include');
+  const [selectedInstances, setSelectedInstances] = useState<string[]>([]);
+
   useEffect(() => {
     api.drives().then(d => setDrives(Array.isArray(d) ? d : []))
       .catch(() => setDrives([]))
       .finally(() => setLoading(false));
   }, [lastRefresh]);
+
+  const driveNames = useMemo(() => {
+    const names = new Set(drives.map(d => d.Name).filter(Boolean) as string[]);
+    return [...names].sort();
+  }, [drives]);
+
+  const instanceNames = useMemo(() => {
+    const names = new Set(drives.map(d => d.InstanceDisplayName).filter(Boolean) as string[]);
+    return [...names].sort();
+  }, [drives]);
 
   const filtered = useMemo(() => {
     let items: EstateDriveViewModel[] = drives.map((d) => {
@@ -54,22 +71,79 @@ export default function EstateDiskPage() {
       );
     }
 
+    if (selectedDrives.length > 0) {
+      items = items.filter(d => {
+        const isSelected = selectedDrives.includes(d.Name || '');
+        return driveMode === 'include' ? isSelected : !isSelected;
+      });
+    }
+
+    if (selectedInstances.length > 0) {
+      items = items.filter(d => {
+        const isSelected = selectedInstances.includes(d.InstanceDisplayName || '');
+        return instanceMode === 'include' ? isSelected : !isSelected;
+      });
+    }
+
     return items.sort((a, b) => b.pct - a.pct);
-  }, [drives, filter]);
+  }, [drives, filter, selectedDrives, driveMode, selectedInstances, instanceMode]);
+
+  const hasActiveFilters = selectedDrives.length > 0 || selectedInstances.length > 0;
 
   if (loading) return <LoadingSpinner />;
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between flex-wrap gap-2">
         <h1 className="text-2xl font-bold text-white">Estate Disk Usage</h1>
-        <input
-          placeholder="Filter by instance or drive..."
-          value={filter}
-          onChange={e => setFilter(e.target.value)}
-          className="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 w-64"
-        />
+        <div className="flex items-center gap-2 flex-wrap">
+          <input
+            placeholder="Filter by instance or drive..."
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+            className="bg-slate-800 border border-slate-600 rounded-lg px-3 py-2 text-sm text-white placeholder-gray-500 w-64"
+          />
+          {instanceNames.length > 0 && (
+            <MultiSelectFilter
+              label="Instances"
+              options={instanceNames}
+              selected={selectedInstances}
+              onChange={setSelectedInstances}
+              mode={instanceMode}
+              onModeChange={setInstanceMode}
+            />
+          )}
+          {driveNames.length > 1 && (
+            <MultiSelectFilter
+              label="Drives"
+              options={driveNames}
+              selected={selectedDrives}
+              onChange={setSelectedDrives}
+              mode={driveMode}
+              onModeChange={setDriveMode}
+            />
+          )}
+        </div>
       </div>
+
+      {hasActiveFilters && (
+        <div className="flex items-center gap-2 text-xs text-gray-400 flex-wrap">
+          <Filter className="w-3 h-3" />
+          <span>Filtering by:</span>
+          {selectedInstances.map(name => (
+            <span key={name} className={clsx('px-2 py-0.5 rounded-full', instanceMode === 'exclude' ? 'bg-red-400/10 text-red-400' : 'bg-blue-400/10 text-blue-400')}>
+              {instanceMode === 'exclude' ? 'not ' : ''}{name}
+              <button onClick={() => setSelectedInstances(prev => prev.filter(n => n !== name))} className="ml-1 hover:text-white">×</button>
+            </span>
+          ))}
+          {selectedDrives.map(name => (
+            <span key={name} className={clsx('px-2 py-0.5 rounded-full', driveMode === 'exclude' ? 'bg-red-400/10 text-red-400' : 'bg-purple-400/10 text-purple-400')}>
+              {driveMode === 'exclude' ? 'not ' : ''}{name}
+              <button onClick={() => setSelectedDrives(prev => prev.filter(n => n !== name))} className="ml-1 hover:text-white">×</button>
+            </span>
+          ))}
+        </div>
+      )}
 
       <div className="glass rounded-xl p-6 gradient-border overflow-x-auto">
         <table className="w-full text-sm">

--- a/frontend/src/pages/EstateDiskPage.tsx
+++ b/frontend/src/pages/EstateDiskPage.tsx
@@ -113,7 +113,7 @@ export default function EstateDiskPage() {
               onModeChange={setInstanceMode}
             />
           )}
-          {driveNames.length > 1 && (
+          {driveNames.length > 0 && (
             <MultiSelectFilter
               label="Drives"
               options={driveNames}

--- a/frontend/src/utils/driveGrowth.ts
+++ b/frontend/src/utils/driveGrowth.ts
@@ -1,0 +1,44 @@
+import type { DriveGrowthPoint } from '../api/types';
+
+export interface DriveGrowthEstimate {
+  bytesPerDay: number | null;
+  daysUntilFull: number | null;
+  estFullDate: Date | null;
+}
+
+const EMPTY_ESTIMATE: DriveGrowthEstimate = { bytesPerDay: null, daysUntilFull: null, estFullDate: null };
+
+// Below this span a rate is mostly measurement noise (e.g. two collection
+// cycles a few minutes apart), so we'd rather show nothing than a wild
+// extrapolation from it.
+const MIN_SPAN_HOURS = 12;
+
+/**
+ * Derives a fill-rate projection from two REAL dbo.DriveSnapshot data points
+ * (oldest/latest within the requested window) rather than assuming a fixed
+ * growth period. Returns nulls when there isn't enough history yet, or when
+ * free space isn't actually shrinking.
+ */
+export function computeDriveGrowth(point: DriveGrowthPoint | undefined): DriveGrowthEstimate {
+  if (!point || point.dataPoints < 2 || point.oldestFreeSpace == null || point.latestFreeSpace == null) {
+    return EMPTY_ESTIMATE;
+  }
+  if (!point.oldestSnapshotDate || !point.latestSnapshotDate) return EMPTY_ESTIMATE;
+
+  const oldestMs = new Date(point.oldestSnapshotDate).getTime();
+  const latestMs = new Date(point.latestSnapshotDate).getTime();
+  const spanHours = (latestMs - oldestMs) / 3_600_000;
+  if (!Number.isFinite(spanHours) || spanHours < MIN_SPAN_HOURS) return EMPTY_ESTIMATE;
+
+  const spanDays = spanHours / 24;
+  const bytesLost = point.oldestFreeSpace - point.latestFreeSpace; // positive = filling up
+  const bytesPerDay = bytesLost / spanDays;
+
+  if (bytesPerDay <= 0) {
+    return { bytesPerDay, daysUntilFull: null, estFullDate: null };
+  }
+
+  const daysUntilFull = point.latestFreeSpace / bytesPerDay;
+  const estFullDate = new Date(Date.now() + daysUntilFull * 86_400_000);
+  return { bytesPerDay, daysUntilFull, estFullDate };
+}


### PR DESCRIPTION
## Description

Adds exclude filters, multi-select (drive letter and instance), free-text
search, and a side-by-side comparison view to the Drives page; the same
include/exclude multi-select filters are added to the Estate Disk view.
Comparison "growth" is real: GET /api/drives/growth reads the oldest and
newest dbo.DriveSnapshot row per drive within the window and the frontend
derives a rate from those two actual data points (no assumed growth
period). Closes #101.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: ___

## Checklist

- [x] `npm run build` passes (frontend)
- [x] `dotnet build` passes (backend)
- [x] Tested in browser (dark theme)
- [x] No new TypeScript errors
- [x] SQL queries use parameterized `@param` (no string concat)

## Screenshots
<img width="768" height="306" alt="image" src="https://github.com/user-attachments/assets/cef3d188-2b59-424e-8bb4-f8c0e34ae87d" />

