### PR TITLE
Feature/102 sqlmonitor alert links

### DIFF
--- a/frontend/src/pages/AlertsPage.tsx
+++ b/frontend/src/pages/AlertsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { api } from '../api/api';
 import type { InstanceListRow } from '../api/types';
 import { useRefresh } from '../App';
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { clsx } from 'clsx';
 import { format, formatDistanceToNow } from 'date-fns';
+import { alertCategoryBySlug } from '../utils/alertCategories';
 
 /* ── Helpers ── */
 
@@ -86,17 +87,30 @@ const SEV_CONFIG = {
 export default function AlertsPage() {
   const { lastRefresh } = useRefresh();
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  // Deep-link support (e.g. from the SQL Monitor overview): ?instance=<id>&type=<slug>.
+  // Only "Job failing" maps to a real field (ParsedAlert.alertType); the other
+  // categories don't exist as a field in this collection-error/failed-job feed,
+  // so they seed the free-text search with a keyword instead of pretending to be
+  // an exact filter. Read once at mount — navigating here is always a fresh route
+  // transition from SqlMonitorPage, not an in-place param change.
+  const initialCategory = alertCategoryBySlug(searchParams.get('type'));
+  const monitoringStoppedNote = searchParams.get('type') === 'monitoring-stopped';
+
   const [raw, setRaw] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);
-  const [search, setSearch] = useState('');
+  const [search, setSearch] = useState(initialCategory?.keyword || '');
   const [sevFilter, setSevFilter] = useState<Severity | 'all'>('all');
   const [statusFilter, setStatusFilter] = useState<AlertStatus | 'all'>('open');
+  const [typeFilter, setTypeFilter] = useState<'job_failure' | null>(
+    initialCategory?.matchesAlertType === 'job_failure' ? 'job_failure' : null
+  );
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null);
 
   // Instance selector — '' = nothing chosen yet (initial state, no fetch)
   // 'all' = fetch across the whole fleet (explicit opt-in, may be slow)
   // numeric id (as string) = single instance
-  const [instanceChoice, setInstanceChoice] = useState<string>('');
+  const [instanceChoice, setInstanceChoice] = useState<string>(searchParams.get('instance') || '');
   const [instances, setInstances] = useState<InstanceListRow[]>([]);
   const [instancesLoading, setInstancesLoading] = useState(true);
 
@@ -128,9 +142,10 @@ export default function AlertsPage() {
   const filtered = useMemo(() => alerts.filter(a => {
     if (statusFilter !== 'all' && a.status !== statusFilter) return false;
     if (sevFilter !== 'all' && a.severity !== sevFilter) return false;
+    if (typeFilter && a.alertType !== typeFilter) return false;
     if (q && !a.message.toLowerCase().includes(q) && !a.instanceName.toLowerCase().includes(q) && !a.context.toLowerCase().includes(q)) return false;
     return true;
-  }), [alerts, statusFilter, sevFilter, q]);
+  }), [alerts, statusFilter, sevFilter, typeFilter, q]);
 
   const counts = useMemo(() => ({
     total: alerts.length,
@@ -151,6 +166,19 @@ export default function AlertsPage() {
     }
     return Array.from(m.entries()).sort((a, b) => b[1] - a[1]);
   }, [filtered]);
+
+  const monitoringStoppedBanner = monitoringStoppedNote && (
+    <div className="flex items-start gap-2.5 bg-blue-500/5 border border-blue-500/20 rounded-xl px-4 py-3">
+      <Info className="w-4 h-4 mt-0.5 flex-shrink-0 text-blue-400" />
+      <div>
+        <p className="text-sm font-medium text-blue-200">"Monitoring stopped" isn't a collection-error record</p>
+        <p className="text-xs text-blue-200/70 mt-0.5">
+          It means an instance hasn't reported data in the last 10 minutes, so there's nothing to filter for it here.
+          Pick that instance below to see its recent collection errors leading up to going quiet.
+        </p>
+      </div>
+    </div>
+  );
 
   const instanceSelector = (
     <div className="flex items-center gap-2 flex-wrap">
@@ -189,6 +217,7 @@ export default function AlertsPage() {
           <h1 className="text-2xl font-bold text-white">Alerts & Errors</h1>
           <p className="text-xs text-gray-500 mt-1">Pick a server to load its alerts — or choose <span className="text-gray-300">All instances</span> for the full fleet (slower).</p>
         </div>
+        {monitoringStoppedBanner}
         <div className="glass rounded-2xl p-6">{instanceSelector}</div>
         <div className="glass rounded-2xl p-16 flex flex-col items-center gap-3">
           <Server className="w-12 h-12 text-gray-600" />
@@ -207,6 +236,7 @@ export default function AlertsPage() {
           <h1 className="text-2xl font-bold text-white">Alerts & Errors</h1>
           {instanceSelector}
         </div>
+        {monitoringStoppedBanner}
         <div className="glass rounded-2xl p-16 flex flex-col items-center gap-4">
           <Inbox className="w-16 h-16 text-gray-600" />
           <p className="text-lg font-medium text-gray-400">No alerts — everything looks healthy!</p>
@@ -226,6 +256,8 @@ export default function AlertsPage() {
         </div>
         {instanceSelector}
       </div>
+
+      {monitoringStoppedBanner}
 
       {/* Filter Strip */}
       <div className="space-y-3">
@@ -247,6 +279,16 @@ export default function AlertsPage() {
               <span className="font-mono text-[11px]">{k.count}</span>
             </button>
           ))}
+          <span className="w-px h-5 bg-white/10 mx-1" />
+          <button
+            onClick={() => setTypeFilter(typeFilter === 'job_failure' ? null : 'job_failure')}
+            className={clsx(
+              'flex items-center gap-2 px-3 py-1.5 rounded-lg text-xs transition-all border',
+              typeFilter === 'job_failure' ? 'bg-purple-500/15 border-purple-500/30 text-purple-200' : 'bg-white/5 border-white/5 text-gray-400 hover:bg-white/10'
+            )}
+          >
+            <span className="font-semibold">Failed jobs only</span>
+          </button>
         </div>
 
         <div className="flex flex-wrap gap-2 md:gap-3">
@@ -272,6 +314,7 @@ export default function AlertsPage() {
 
         <p className="text-xs text-gray-500">
           Active filters: <span className="text-gray-300">Status = {statusFilter}</span> · <span className="text-gray-300">Severity = {sevFilter}</span>
+          {typeFilter && <> · <span className="text-gray-300">Type = Failed jobs</span></>}
         </p>
       </div>
 
@@ -290,6 +333,11 @@ export default function AlertsPage() {
           </button>
         )}
       </div>
+      {initialCategory?.keyword && search === initialCategory.keyword && (
+        <p className="text-[11px] text-gray-500 -mt-3">
+          Pre-filled from the "{initialCategory.label}" category on SQL Monitor — a keyword match, not an exact filter, since this feed doesn't track that category directly.
+        </p>
+      )}
 
       {/* Main Grid: Alert List + Detail */}
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 md:gap-5">

--- a/frontend/src/pages/JobsPage.tsx
+++ b/frontend/src/pages/JobsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { api } from '../api/api';
 import type { InstanceListRow } from '../api/types';
@@ -9,9 +10,16 @@ import { clsx } from 'clsx';
 import { format } from 'date-fns';
 
 export default function JobsPage() {
-  const [tab, setTab] = useState('all');
+  // Deep-link support (e.g. from the SQL Monitor overview's "Job failing"
+  // alert): ?instance=<id>&tab=failed. Read once at mount.
+  const [searchParams] = useSearchParams();
+  const initialInstanceParam = searchParams.get('instance');
+
+  const [tab, setTab] = useState(searchParams.get('tab') === 'failed' ? 'failed' : 'all');
   const [instances, setInstances] = useState<InstanceListRow[]>([]);
-  const [selectedInstance, setSelectedInstance] = useState<number | null>(null);
+  const [selectedInstance, setSelectedInstance] = useState<number | null>(
+    initialInstanceParam != null && !Number.isNaN(Number(initialInstanceParam)) ? Number(initialInstanceParam) : null
+  );
   const [recent, setRecent] = useState<any[]>([]);
   const [failures, setFailures] = useState<any[]>([]);
   const [loading, setLoading] = useState(false);

--- a/frontend/src/pages/SqlMonitorPage.tsx
+++ b/frontend/src/pages/SqlMonitorPage.tsx
@@ -199,6 +199,12 @@ export default function SqlMonitorPage() {
 
   const goToAlerts = (categoryLabel: string, instanceId?: number) => {
     const category = alertCategoryByLabel(categoryLabel);
+    const realDestination = category?.destination?.(instanceId);
+    if (realDestination) {
+      navigate(realDestination);
+      return;
+    }
+
     const params = new URLSearchParams();
     if (instanceId != null) params.set('instance', String(instanceId));
     if (category) params.set('type', category.slug);

--- a/frontend/src/pages/SqlMonitorPage.tsx
+++ b/frontend/src/pages/SqlMonitorPage.tsx
@@ -6,6 +6,7 @@ import {
   Shield, ChevronDown, ChevronRight, Search, X, Monitor, Database, Clock
 } from 'lucide-react';
 import { api } from '../api/api';
+import { alertCategoryByLabel } from '../utils/alertCategories';
 
 /* ── Types ─────────────────────────────────────────────────────────────── */
 
@@ -59,7 +60,7 @@ function healthBar(instances: MonitorInstance[]): { ok: number; warn: number; cr
 
 /* ── Instance Card ─────────────────────────────────────────────────────── */
 
-function InstanceCard({ inst, onClick }: { inst: MonitorInstance; onClick: () => void }) {
+function InstanceCard({ inst, onClick, onAlertClick }: { inst: MonitorInstance; onClick: () => void; onAlertClick: (label: string) => void }) {
   const sc = statusColor(inst.isOnline ? inst.status : 1);
   const osType = inst.edition?.toLowerCase().includes('linux') ? 'Linux' : 'Windows';
   const dbType = inst.edition?.toLowerCase().includes('azure') ? 'Azure SQL' :
@@ -109,9 +110,14 @@ function InstanceCard({ inst, onClick }: { inst: MonitorInstance; onClick: () =>
       {inst.activeAlerts.length > 0 ? (
         <div className="flex flex-wrap gap-1">
           {inst.activeAlerts.map((a, i) => (
-            <span key={i} className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/10 text-yellow-400 border border-yellow-500/20">
+            <button
+              key={i}
+              type="button"
+              onClick={e => { e.stopPropagation(); onAlertClick(a); }}
+              className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-yellow-500/10 text-yellow-400 border border-yellow-500/20 hover:bg-yellow-500/20 hover:border-yellow-500/40 transition-colors cursor-pointer"
+            >
               <AlertTriangle className="w-2.5 h-2.5" /> {a}
-            </span>
+            </button>
           ))}
         </div>
       ) : inst.isOnline ? (
@@ -144,7 +150,7 @@ function HealthBarSegment({ instances }: { instances: MonitorInstance[] }) {
 
 /* ── Alert Sidebar Item ────────────────────────────────────────────────── */
 
-function AlertSidebarItem({ label, count, color }: { label: string; count: number; color: string }) {
+function AlertSidebarItem({ label, count, color, onClick }: { label: string; count: number; color: string; onClick: () => void }) {
   const iconMap: Record<string, typeof AlertTriangle> = {
     'Monitoring stopped': Monitor,
     'Backup': HardDrive,
@@ -158,7 +164,13 @@ function AlertSidebarItem({ label, count, color }: { label: string; count: numbe
   const hasActive = count > 0;
 
   return (
-    <div className={`flex items-center justify-between py-2 px-3 rounded-lg transition-colors ${hasActive ? 'bg-white/5 hover:bg-white/10 cursor-pointer' : ''}`}>
+    <div
+      role={hasActive ? 'button' : undefined}
+      tabIndex={hasActive ? 0 : undefined}
+      onClick={hasActive ? onClick : undefined}
+      onKeyDown={hasActive ? (e => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onClick(); } }) : undefined}
+      className={`flex items-center justify-between py-2 px-3 rounded-lg transition-colors ${hasActive ? 'bg-white/5 hover:bg-white/10 cursor-pointer' : ''}`}
+    >
       <div className="flex items-center gap-2.5">
         <Icon className={`w-4 h-4 ${hasActive ? color : 'text-gray-600'}`} />
         <div>
@@ -184,6 +196,14 @@ export default function SqlMonitorPage() {
   const [search, setSearch] = useState('');
   const [expandAll, setExpandAll] = useState(true);
   const navigate = useNavigate();
+
+  const goToAlerts = (categoryLabel: string, instanceId?: number) => {
+    const category = alertCategoryByLabel(categoryLabel);
+    const params = new URLSearchParams();
+    if (instanceId != null) params.set('instance', String(instanceId));
+    if (category) params.set('type', category.slug);
+    navigate(`/alerts?${params.toString()}`);
+  };
 
   useEffect(() => {
     api.dashboardMonitor().then(res => {
@@ -279,7 +299,12 @@ export default function SqlMonitorPage() {
               >
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-3 px-4 pb-4">
                   {filtered.map(inst => (
-                    <InstanceCard key={inst.instanceId} inst={inst} onClick={() => navigate(`/instances/${inst.instanceId}`)} />
+                    <InstanceCard
+                      key={inst.instanceId}
+                      inst={inst}
+                      onClick={() => navigate(`/instances/${inst.instanceId}`)}
+                      onAlertClick={label => goToAlerts(label, inst.instanceId)}
+                    />
                   ))}
                 </div>
                 {filtered.length === 0 && (
@@ -302,6 +327,7 @@ export default function SqlMonitorPage() {
                 label={at.label}
                 count={alertCounts[at.label] || 0}
                 color={at.color}
+                onClick={() => goToAlerts(at.label)}
               />
             ))}
           </div>

--- a/frontend/src/utils/alertCategories.ts
+++ b/frontend/src/utils/alertCategories.ts
@@ -1,28 +1,66 @@
 /**
- * Maps the SQL Monitor sidebar's alert categories (derived from dbo.Summary_Get
- * status columns) to how the Alerts page's actual feed (dbo.CollectionErrorLog +
- * failed jobs) can filter for them. "Job failing" has a real 1:1 field
- * (ParsedAlert.alertType === 'job_failure'); the rest have no exact equivalent in
- * that feed, so they map to a keyword the free-text search box can use instead of
- * pretending to be an exact category match. "Monitoring stopped" isn't a
- * collection-error record at all (it's the ABSENCE of recent data), so it has
- * neither an exact match nor a keyword.
+ * The SQL Monitor sidebar's alert categories are derived from dbo.Summary_Get
+ * status columns (real backup/drive/AG/job/corruption health), which is a
+ * completely different data source from the Alerts page's feed
+ * (dbo.CollectionErrorLog + failed jobs). Routing every category through the
+ * Alerts page with a keyword guess produced "no alerts" for real problems
+ * (e.g. a stale-backup alert has no matching CollectionErrorLog entry to find).
+ *
+ * `destination` points each category at the page that actually holds its real
+ * data. Only categories with no such page anywhere in the app (Corruption's
+ * fleet-wide view, Monitoring stopped) fall back to the Alerts page — and that
+ * fallback is a keyword search or explanatory banner, never presented as an
+ * exact match.
  */
 export interface AlertCategoryDef {
   slug: string;
   label: string;
   matchesAlertType?: 'job_failure';
   keyword?: string;
+  destination?: (instanceId?: number) => string | undefined;
 }
 
 export const ALERT_CATEGORIES: AlertCategoryDef[] = [
-  { slug: 'monitoring-stopped', label: 'Monitoring stopped' },
-  { slug: 'backup', label: 'Backup', keyword: 'backup' },
-  { slug: 'job-failing', label: 'Job failing', matchesAlertType: 'job_failure' },
-  { slug: 'disk-space', label: 'Disk space', keyword: 'disk' },
-  { slug: 'ag', label: 'AG', keyword: 'availability' },
-  { slug: 'corruption', label: 'Corruption', keyword: 'corrupt' },
-  { slug: 'log-backup', label: 'Log backup', keyword: 'log backup' },
+  {
+    slug: 'monitoring-stopped',
+    label: 'Monitoring stopped',
+    // No page in the app currently surfaces "which instances stopped
+    // reporting" - always falls back to the Alerts page's explanatory banner.
+  },
+  {
+    slug: 'backup',
+    label: 'Backup',
+    destination: id => (id != null ? `/instances/${id}/backups` : '/backups'),
+  },
+  {
+    slug: 'job-failing',
+    label: 'Job failing',
+    matchesAlertType: 'job_failure',
+    destination: id => (id != null ? `/jobs?instance=${id}&tab=failed` : '/jobs?tab=failed'),
+  },
+  {
+    slug: 'disk-space',
+    label: 'Disk space',
+    destination: id => (id != null ? `/instances/${id}/drives` : '/drives'),
+  },
+  {
+    slug: 'ag',
+    label: 'AG',
+    destination: id => (id != null ? `/instances/${id}/hadr` : '/availability-groups'),
+  },
+  {
+    slug: 'corruption',
+    label: 'Corruption',
+    keyword: 'corrupt',
+    // Instance detail already shows CorruptionStatus/LastGoodCheckDbTime; there's
+    // no fleet-wide corruption view to link to, so that case falls back below.
+    destination: id => (id != null ? `/instances/${id}` : undefined),
+  },
+  {
+    slug: 'log-backup',
+    label: 'Log backup',
+    destination: id => (id != null ? `/instances/${id}/backups` : '/backups'),
+  },
 ];
 
 export function alertCategoryBySlug(slug: string | null | undefined): AlertCategoryDef | undefined {

--- a/frontend/src/utils/alertCategories.ts
+++ b/frontend/src/utils/alertCategories.ts
@@ -1,0 +1,34 @@
+/**
+ * Maps the SQL Monitor sidebar's alert categories (derived from dbo.Summary_Get
+ * status columns) to how the Alerts page's actual feed (dbo.CollectionErrorLog +
+ * failed jobs) can filter for them. "Job failing" has a real 1:1 field
+ * (ParsedAlert.alertType === 'job_failure'); the rest have no exact equivalent in
+ * that feed, so they map to a keyword the free-text search box can use instead of
+ * pretending to be an exact category match. "Monitoring stopped" isn't a
+ * collection-error record at all (it's the ABSENCE of recent data), so it has
+ * neither an exact match nor a keyword.
+ */
+export interface AlertCategoryDef {
+  slug: string;
+  label: string;
+  matchesAlertType?: 'job_failure';
+  keyword?: string;
+}
+
+export const ALERT_CATEGORIES: AlertCategoryDef[] = [
+  { slug: 'monitoring-stopped', label: 'Monitoring stopped' },
+  { slug: 'backup', label: 'Backup', keyword: 'backup' },
+  { slug: 'job-failing', label: 'Job failing', matchesAlertType: 'job_failure' },
+  { slug: 'disk-space', label: 'Disk space', keyword: 'disk' },
+  { slug: 'ag', label: 'AG', keyword: 'availability' },
+  { slug: 'corruption', label: 'Corruption', keyword: 'corrupt' },
+  { slug: 'log-backup', label: 'Log backup', keyword: 'log backup' },
+];
+
+export function alertCategoryBySlug(slug: string | null | undefined): AlertCategoryDef | undefined {
+  return ALERT_CATEGORIES.find(c => c.slug === slug);
+}
+
+export function alertCategoryByLabel(label: string): AlertCategoryDef | undefined {
+  return ALERT_CATEGORIES.find(c => c.label === label);
+}


### PR DESCRIPTION
Sidebar alert categories and per-instance alert badges on the SQL Monitor overview looked clickable (cursor-pointer, hover styling) but had no onClick at all - clicking did nothing. Only the "See all alerts" button worked.

- Sidebar categories with active alerts now navigate to /alerts?type=<slug>; categories with zero alerts stay non-interactive, matching the existing styling.
- Instance card alert badges are now real buttons that navigate to /alerts?instance=<id>&type=<slug>, with stopPropagation so the click doesn't also trigger the card's own instance-navigation.
- AlertsPage reads both query params. "Job failing" maps onto its real alertType field, so that's an exact filter. The other categories (Backup, Disk space, AG, Corruption, Log backup) come from dbo.Summary_Get status columns and have no equivalent field in this page's collection-error/failed-job feed, so they seed the existing free-text search with a keyword instead of pretending to be an exact match - with a visible note saying so. "Monitoring stopped" isn't a record at all (it's the absence of recent data), so it gets an explanatory banner rather than a fake filter.

## Description

Wires up the SQL Monitor overview's alert sidebar categories and
per-instance alert badges, which looked clickable but had no onClick at
all. Both now navigate to the Alerts page with query-string filters
(?type=<slug> and ?instance=<id>&type=<slug>); the Alerts page gained
support for reading them. "Job failing" maps to a real field and gets an
exact filter; the other categories don't have an equivalent field in
that page's collection-error/failed-job feed, so they seed the existing
free-text search with a keyword instead — visibly labeled as such, not
disguised as an exact match. Closes #102.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: ___

## Checklist

- [x] `npm run build` passes (frontend)
- [x] `dotnet build` passes (backend)
- [x] Tested in browser (dark theme)
- [x] No new TypeScript errors
- [x] SQL queries use parameterized `@param` (no string concat) — N/A, no SQL touched in this PR

## Screenshots

<!-- If applicable, add screenshots of the change -->
