### PR TITLE
Surface DBA Dash's real Query Store, corruption, Resource Governor, security, and misc. health data (#109)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # .NET
 backend/bin/
 backend/obj/
+backend/publish/
 backend.tests/bin/
 backend.tests/obj/
 backend/Properties/launchSettings.json

--- a/backend/Auth/AppAuthorization.cs
+++ b/backend/Auth/AppAuthorization.cs
@@ -18,4 +18,5 @@ public static class AppRoles
 public static class AppPolicies
 {
     public const string AdminOnly = "AdminOnly";
+    public const string OperatorOrAdmin = "OperatorOrAdmin";
 }

--- a/backend/Endpoints/AvailabilityEndpointMappings.cs
+++ b/backend/Endpoints/AvailabilityEndpointMappings.cs
@@ -69,7 +69,29 @@ public static class AvailabilityEndpointMappings
                     )
                     """, cancellationToken, ("@id", id));
 
-                return Results.Ok(new { ags, replicas, databases });
+                var mirroring = await sql.QueryAsync("""
+                    SELECT dm.DatabaseID, d.name AS DatabaseName,
+                           dm.mirroring_state_desc, dm.mirroring_role_desc, dm.mirroring_safety_level_desc,
+                           dm.mirroring_partner_name, dm.mirroring_partner_instance,
+                           dm.mirroring_witness_name, dm.mirroring_witness_state_desc,
+                           dm.mirroring_redo_queue, dm.mirroring_redo_queue_type,
+                           dmp.mirroring_state_desc AS PartnerStateDesc
+                    FROM dbo.DatabaseMirroring dm
+                    JOIN dbo.Databases d ON dm.DatabaseID = d.DatabaseID
+                    LEFT JOIN dbo.DatabaseMirroring dmp ON dmp.mirroring_guid = dm.mirroring_guid AND dmp.InstanceID <> dm.InstanceID
+                    WHERE dm.InstanceID = @id
+                    ORDER BY d.name
+                    """, cancellationToken, ("@id", id));
+
+                var logShipping = await sql.QueryAsync("""
+                    SELECT lr.DatabaseID, d.name AS DatabaseName, lr.restore_date, lr.backup_start_date, lr.last_file
+                    FROM dbo.LogRestores lr
+                    JOIN dbo.Databases d ON lr.DatabaseID = d.DatabaseID
+                    WHERE lr.InstanceID = @id
+                    ORDER BY d.name
+                    """, cancellationToken, ("@id", id));
+
+                return Results.Ok(new { ags, replicas, databases, mirroring, logShipping });
             }
             catch (Exception ex)
             {
@@ -78,7 +100,9 @@ public static class AvailabilityEndpointMappings
                     error = ex.Message,
                     ags = Array.Empty<object>(),
                     replicas = Array.Empty<object>(),
-                    databases = Array.Empty<object>()
+                    databases = Array.Empty<object>(),
+                    mirroring = Array.Empty<object>(),
+                    logShipping = Array.Empty<object>()
                 });
             }
         }).RequireAuthorization();

--- a/backend/Endpoints/CorruptionEndpointMappings.cs
+++ b/backend/Endpoints/CorruptionEndpointMappings.cs
@@ -1,0 +1,107 @@
+using System.Security.Claims;
+using DBADashWebView.Auth;
+using DBADashWebView.Data;
+
+namespace DBADashWebView.Endpoints;
+
+public sealed record AcknowledgeCorruptionRequest(bool Clear);
+
+/// <summary>
+/// Surfaces DBA Dash's real dbo.Corruption data (consistency-check findings from
+/// msdb.dbo.suspect_pages and the mirroring/HADR auto-page-repair DMVs) instead of
+/// just the CorruptionStatus colour dot elsewhere in the app. It's a per-database
+/// status summary (row count + last-seen date per source), not a per-page event log -
+/// that's the real granularity DBA Dash collects.
+/// </summary>
+public static class CorruptionEndpointMappings
+{
+    private static readonly Dictionary<int, string> SourceLabels = new()
+    {
+        [1] = "msdb.suspect_pages",
+        [2] = "Mirroring auto page repair",
+        [3] = "HADR auto page repair",
+    };
+
+    public static IEndpointRouteBuilder MapCorruptionEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/api/corruption", async (int? instanceId, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            if (instanceId is int requestedInstanceId)
+            {
+                var deny = await user.EnsureInstanceAccessAsync(requestedInstanceId, sql, cancellationToken);
+                if (deny is not null) return deny;
+            }
+
+            try
+            {
+                var (scopeSnippet, scopeParameters) = user.ScopedInstanceFilter("d.InstanceID");
+                var filter = instanceId.HasValue ? "AND d.InstanceID = @instanceId" : string.Empty;
+                var rows = await sql.QueryAsync(
+                    $"""
+                    SELECT c.DatabaseID, d.name AS DatabaseName, d.InstanceID,
+                           COALESCE(i.InstanceDisplayName, i.Instance) AS InstanceDisplayName,
+                           c.SourceTable, c.UpdateDate, c.AckDate, c.CountOfRows
+                    FROM dbo.Corruption c
+                    JOIN dbo.Databases d ON c.DatabaseID = d.DatabaseID
+                    JOIN dbo.Instances i ON d.InstanceID = i.InstanceID
+                    WHERE d.IsActive = 1 {filter} {scopeSnippet}
+                    ORDER BY c.UpdateDate DESC
+                    """,
+                    cancellationToken,
+                    [("@instanceId", instanceId.HasValue ? instanceId.Value : DBNull.Value), .. scopeParameters]);
+
+                var data = rows.Select(row => new
+                {
+                    databaseId = Convert.ToInt32(row["DatabaseID"]),
+                    databaseName = row["DatabaseName"]?.ToString(),
+                    instanceId = Convert.ToInt32(row["InstanceID"]),
+                    instanceDisplayName = row["InstanceDisplayName"]?.ToString(),
+                    sourceTable = Convert.ToInt32(row["SourceTable"]),
+                    source = SourceLabels.GetValueOrDefault(Convert.ToInt32(row["SourceTable"]), "Unknown"),
+                    updateDate = row["UpdateDate"],
+                    ackDate = row["AckDate"],
+                    isAcknowledged = row["AckDate"] is not null,
+                    countOfRows = row["CountOfRows"] is null ? (int?)null : Convert.ToInt32(row["CountOfRows"]),
+                }).ToList();
+
+                return Results.Ok(new { data });
+            }
+            catch (Exception ex)
+            {
+                return Results.Ok(new { error = ex.Message, data = Array.Empty<object>() });
+            }
+        }).RequireAuthorization();
+
+        endpoints.MapPost("/api/corruption/{databaseId:int}/acknowledge", async (
+            int databaseId,
+            AcknowledgeCorruptionRequest request,
+            ClaimsPrincipal user,
+            SqlDataService sql,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var instanceRows = await sql.QueryAsync(
+                    "SELECT InstanceID FROM dbo.Databases WHERE DatabaseID = @databaseId",
+                    cancellationToken, ("@databaseId", databaseId));
+                if (instanceRows.Count == 0) return Results.NotFound();
+
+                var instanceId = Convert.ToInt32(instanceRows[0]["InstanceID"]);
+                var deny = await user.EnsureInstanceAccessAsync(instanceId, sql, cancellationToken);
+                if (deny is not null) return deny;
+
+                await sql.QueryAsync(
+                    "EXEC dbo.Corruption_Ack @DatabaseID = @databaseId, @Clear = @clear",
+                    cancellationToken, ("@databaseId", databaseId), ("@clear", request.Clear));
+
+                return Results.Ok(new { success = true });
+            }
+            catch (Exception ex)
+            {
+                return Results.Problem(title: "Unable to acknowledge corruption", detail: ex.Message, statusCode: StatusCodes.Status500InternalServerError);
+            }
+        }).RequireAuthorization(AppPolicies.OperatorOrAdmin);
+
+        return endpoints;
+    }
+}

--- a/backend/Endpoints/InstanceEndpointMappings.cs
+++ b/backend/Endpoints/InstanceEndpointMappings.cs
@@ -99,6 +99,40 @@ public static class InstanceEndpointMappings
             }
         }).RequireAuthorization();
 
+        // A REAL baseline - the average SQLProcessCPU for the same time-of-day
+        // bucket, computed from actual historical dbo.CPU rows older than the
+        // window currently being charted. (The "Baseline (last week)" toggle in
+        // the frontend used to be current-value + a sine wave with no real data
+        // behind it at all.)
+        endpoints.MapGet("/api/instances/{id:int}/cpu/baseline", async (int id, int? hours, int? lookbackDays, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            var deny = await user.EnsureInstanceAccessAsync(id, sql, cancellationToken);
+            if (deny is not null) return deny;
+            var effectiveHours = Math.Clamp(hours ?? 24, 1, 336);
+            var effectiveLookbackDays = Math.Clamp(lookbackDays ?? 14, 1, 90);
+            const int bucketMinutes = 15;
+            try
+            {
+                var data = await sql.QueryAsync("""
+                    SELECT
+                        (DATEPART(hour, EventTime) * 60 + (DATEPART(minute, EventTime) / 15) * 15) AS MinuteOfDay,
+                        AVG(CAST(SQLProcessCPU AS FLOAT)) AS AvgCpu,
+                        COUNT(*) AS SampleCount
+                    FROM dbo.CPU
+                    WHERE InstanceID = @id
+                      AND EventTime >= DATEADD(day, -@lookbackDays, GETUTCDATE())
+                      AND EventTime < DATEADD(hour, -@hours, GETUTCDATE())
+                    GROUP BY DATEPART(hour, EventTime), (DATEPART(minute, EventTime) / 15)
+                    ORDER BY MinuteOfDay
+                    """, cancellationToken, ("@id", id), ("@lookbackDays", effectiveLookbackDays), ("@hours", effectiveHours));
+                return Results.Ok(new { data, bucketMinutes });
+            }
+            catch (Exception ex)
+            {
+                return Results.Ok(new { error = ex.Message, data = Array.Empty<object>(), bucketMinutes });
+            }
+        }).RequireAuthorization();
+
         endpoints.MapGet("/api/instances/{id:int}/waits", async (int id, int? hours, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
         {
             var deny = await user.EnsureInstanceAccessAsync(id, sql, cancellationToken);

--- a/backend/Endpoints/InstanceEndpointMappings.cs
+++ b/backend/Endpoints/InstanceEndpointMappings.cs
@@ -133,6 +133,56 @@ public static class InstanceEndpointMappings
             }
         }).RequireAuthorization();
 
+        endpoints.MapGet("/api/instances/{id:int}/table-sizes", async (int id, int? growthDays, int? top, int? databaseId, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            var deny = await user.EnsureInstanceAccessAsync(id, sql, cancellationToken);
+            if (deny is not null) return deny;
+            var effectiveGrowthDays = Math.Clamp(growthDays ?? 30, 1, 365);
+            var effectiveTop = Math.Clamp(top ?? 100, 1, 500);
+            try
+            {
+                var data = await sql.QueryAsync("""
+                    DECLARE @minSnapshotDate DATETIME2 = DATEADD(day, -@growthDays, SYSUTCDATETIME());
+                    WITH T AS (
+                        SELECT TS.InstanceID, TS.SnapshotDate, TS.DatabaseID, TS.ObjectID,
+                               TS.row_count, TS.reserved_pages, TS.used_pages, TS.data_pages, TS.index_pages,
+                               RANK() OVER (PARTITION BY TS.ObjectID ORDER BY TS.SnapshotDate DESC) AS Latest,
+                               RANK() OVER (PARTITION BY TS.ObjectID ORDER BY TS.SnapshotDate ASC) AS Oldest
+                        FROM dbo.TableSize TS
+                        WHERE TS.InstanceID = @id
+                          AND TS.SnapshotDate >= @minSnapshotDate
+                          AND (TS.DatabaseID = @databaseId OR @databaseId IS NULL)
+                    )
+                    SELECT TOP (@top)
+                        Latest.ObjectID, Latest.DatabaseID, D.name AS DatabaseName, O.SchemaName, O.ObjectName,
+                        Latest.SnapshotDate,
+                        Latest.row_count AS Rows,
+                        Latest.reserved_pages * 8 AS ReservedKb,
+                        Latest.used_pages * 8 AS UsedKb,
+                        Latest.data_pages * 8 AS DataKb,
+                        Latest.index_pages * 8 AS IndexKb,
+                        (Latest.row_count - Oldest.row_count) * 1440.0 / NULLIF(DATEDIFF(minute, Oldest.SnapshotDate, Latest.SnapshotDate), 0) AS AvgRowsPerDay,
+                        (Latest.used_pages - Oldest.used_pages) * 8 * 1440.0 / NULLIF(DATEDIFF(minute, Oldest.SnapshotDate, Latest.SnapshotDate), 0) AS AvgKbPerDay,
+                        NULLIF(DATEDIFF(minute, Oldest.SnapshotDate, Latest.SnapshotDate), 0) / 1440.0 AS CalcDays
+                    FROM T Latest
+                    JOIN dbo.Databases D ON D.DatabaseID = Latest.DatabaseID
+                    JOIN dbo.DBObjects O ON Latest.ObjectID = O.ObjectID AND O.DatabaseID = Latest.DatabaseID
+                    LEFT JOIN T Oldest ON Latest.ObjectID = Oldest.ObjectID AND Oldest.Oldest = 1
+                    WHERE Latest.Latest = 1
+                      AND D.IsActive = 1
+                      AND O.IsActive = 1
+                    ORDER BY Latest.reserved_pages DESC
+                    """, cancellationToken,
+                    ("@id", id), ("@growthDays", effectiveGrowthDays), ("@top", effectiveTop),
+                    ("@databaseId", databaseId.HasValue ? databaseId.Value : DBNull.Value));
+                return Results.Ok(new { data, growthDays = effectiveGrowthDays });
+            }
+            catch (Exception ex)
+            {
+                return Results.Ok(new { error = ex.Message, data = Array.Empty<object>(), growthDays = effectiveGrowthDays });
+            }
+        }).RequireAuthorization();
+
         endpoints.MapGet("/api/instances/{id:int}/waits", async (int id, int? hours, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
         {
             var deny = await user.EnsureInstanceAccessAsync(id, sql, cancellationToken);

--- a/backend/Endpoints/MonitoringEndpointMappings.cs
+++ b/backend/Endpoints/MonitoringEndpointMappings.cs
@@ -153,6 +153,33 @@ public static class MonitoringEndpointMappings
             return Results.Ok(new { data, note });
         }).RequireAuthorization();
 
+        endpoints.MapGet("/api/monitoring/trace-flags", async (int? instanceId, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            object data = Array.Empty<object>();
+            var note = string.Empty;
+
+            if (!instanceId.HasValue)
+            {
+                return Results.Ok(new { data, note = "instanceId required" });
+            }
+
+            var deny = await user.EnsureInstanceAccessAsync(instanceId.Value, sql, cancellationToken);
+            if (deny is not null) return deny;
+
+            try
+            {
+                data = await sql.QueryAsync(
+                    "SELECT TraceFlag, ValidFrom FROM dbo.TraceFlags WHERE InstanceID = @instanceId ORDER BY TraceFlag",
+                    cancellationToken, ("@instanceId", instanceId.Value));
+            }
+            catch (Exception ex)
+            {
+                note = $"Trace flags unavailable: {ex.Message}";
+            }
+
+            return Results.Ok(new { data, note });
+        }).RequireAuthorization();
+
         endpoints.MapGet("/api/monitoring/patching", async (ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
         {
             try

--- a/backend/Endpoints/PerformanceEndpointMappings.cs
+++ b/backend/Endpoints/PerformanceEndpointMappings.cs
@@ -64,10 +64,11 @@ public static class PerformanceEndpointMappings
                            rq.login_name,
                            rq.host_name,
                            rq.program_name,
-                           CAST(NULL AS nvarchar(max)) AS query_text
+                           qt.text AS query_text
                     FROM dbo.RunningQueries rq
                     JOIN dbo.Instances i ON rq.InstanceID = i.InstanceID
                     LEFT JOIN dbo.Databases d ON rq.database_id = d.database_id AND rq.InstanceID = d.InstanceID
+                    LEFT JOIN dbo.QueryText qt ON rq.sql_handle = qt.sql_handle
                     WHERE rq.SnapshotDateUTC > DATEADD(hour, -1, GETUTCDATE()) {filter} {scopeSnippet}
                     ORDER BY rq.SnapshotDateUTC DESC
                     """;
@@ -103,9 +104,10 @@ public static class PerformanceEndpointMappings
                            rq.reads,
                            rq.writes,
                            rq.SnapshotDateUTC AS SnapshotDate,
-                           CAST(NULL AS nvarchar(max)) AS query_text
+                           qt.text AS query_text
                     FROM dbo.RunningQueries rq
                     JOIN dbo.Instances i ON rq.InstanceID = i.InstanceID
+                    LEFT JOIN dbo.QueryText qt ON rq.sql_handle = qt.sql_handle
                     WHERE rq.SnapshotDateUTC > DATEADD(hour, -1, GETUTCDATE())
                       AND (rq.blocking_session_id > 0
                            OR rq.session_id IN (
@@ -500,10 +502,12 @@ public static class PerformanceEndpointMappings
         {
             var deny = await user.EnsureInstanceAccessAsync(instanceId, sql, cancellationToken);
             if (deny is not null) return deny;
-            // DBADash stores procedure/object-level execution stats in dbo.ObjectExecutionStats.
-            // There are no separate QueryStoreStats or TopQueries tables in the DBADash schema.
-            // We query ObjectExecutionStats grouped by object to surface the top CPU consumers,
-            // which is the closest equivalent to a Query Store top-queries view. (#55)
+            // DBADash has dbo.QueryPlans/QueryText (keyed by plan_handle/sql_handle) but no
+            // query-level AGGREGATED runtime-stats table to drive a "top queries" ranking from -
+            // only dbo.RunningQueries (point-in-time) and dbo.SlowQueries (individual slow-query
+            // events, which already carry their own captured text). The closest real aggregate is
+            // dbo.ObjectExecutionStats (procedure/object-level), used here as a top-CPU-consumers
+            // view. Real forced-plan history (not an approximation) is a separate endpoint below.
             string note = string.Empty;
             object data = Array.Empty<object>();
             try
@@ -532,6 +536,35 @@ public static class PerformanceEndpointMappings
             catch (Exception ex)
             {
                 note = $"Query Store data unavailable: {ex.Message}";
+            }
+
+            return Results.Ok(new { data, note });
+        }).RequireAuthorization();
+
+        // Real forced-plan audit trail from dbo.PlanForcingLog - who forced/unforced which plan
+        // for which query, when, and its status. Read-only: forcing a plan is a write against the
+        // target SQL Server's actual query plan cache, which stays a DBA Dash desktop client action.
+        endpoints.MapGet("/api/performance/plan-forcing-log", async (int instanceId, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            var deny = await user.EnsureInstanceAccessAsync(instanceId, sql, cancellationToken);
+            if (deny is not null) return deny;
+            string note = string.Empty;
+            object data = Array.Empty<object>();
+            try
+            {
+                const string query = """
+                    SELECT TOP 200
+                        MessageGroupID, InstanceID, database_name, log_date, log_type, user_name,
+                        query_id, plan_id, object_name, query_sql_text, notes, status
+                    FROM dbo.PlanForcingLog
+                    WHERE InstanceID = @instanceId
+                    ORDER BY log_date DESC
+                    """;
+                data = await sql.QueryAsync(query, cancellationToken, ("@instanceId", instanceId));
+            }
+            catch (Exception ex)
+            {
+                note = $"Plan forcing log unavailable: {ex.Message}";
             }
 
             return Results.Ok(new { data, note });

--- a/backend/Endpoints/ResourceGovernorEndpointMappings.cs
+++ b/backend/Endpoints/ResourceGovernorEndpointMappings.cs
@@ -1,0 +1,183 @@
+using System.Security.Claims;
+using DBADashWebView.Auth;
+using DBADashWebView.Data;
+
+namespace DBADashWebView.Endpoints;
+
+/// <summary>
+/// Surfaces DBA Dash's real Resource Governor collection: configuration + change history
+/// from dbo.ResourceGovernorConfigurationHistory, and current pool/workload-group utilization
+/// computed with the same rate formulas as DBA Dash's own
+/// dbo.ResourceGovernorResourcePools_Get / dbo.ResourceGovernorWorkloadGroups_Get procs.
+/// Those procs return every pool/group row (active or retired) with no IsActive filter, so
+/// this endpoint additionally reads the base tables to restrict the response to currently
+/// active pools/groups.
+/// </summary>
+public static class ResourceGovernorEndpointMappings
+{
+    public static IEndpointRouteBuilder MapResourceGovernorEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/api/instances/{id:int}/resource-governor", async (int id, int? hours, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            var deny = await user.EnsureInstanceAccessAsync(id, sql, cancellationToken);
+            if (deny is not null) return deny;
+
+            var effectiveHours = Math.Clamp(hours ?? 24, 1, 168);
+            var toDate = DateTime.UtcNow;
+            var fromDate = toDate.AddHours(-effectiveHours);
+            string note = string.Empty;
+
+            object? config = null;
+            var configHistory = new List<object>();
+            var pools = new List<object>();
+            var workloadGroups = new List<object>();
+
+            try
+            {
+                var configRows = await sql.QueryAsync(
+                    """
+                    SELECT is_enabled, classifier_function, reconfiguration_error, reconfiguration_pending,
+                           max_outstanding_io_per_volume, ValidFrom
+                    FROM dbo.ResourceGovernorConfiguration
+                    WHERE InstanceID = @id
+                    """, cancellationToken, ("@id", id));
+
+                if (configRows.Count > 0)
+                {
+                    var row = configRows[0];
+                    config = new
+                    {
+                        isEnabled = Convert.ToBoolean(row["is_enabled"]),
+                        classifierFunction = row["classifier_function"]?.ToString(),
+                        reconfigurationError = Convert.ToBoolean(row["reconfiguration_error"]),
+                        reconfigurationPending = Convert.ToBoolean(row["reconfiguration_pending"]),
+                        maxOutstandingIoPerVolume = Convert.ToInt32(row["max_outstanding_io_per_volume"]),
+                        validFrom = row["ValidFrom"],
+                    };
+                }
+
+                var historyRows = await sql.QueryAsync(
+                    """
+                    SELECT TOP 20 is_enabled, classifier_function, reconfiguration_error, reconfiguration_pending,
+                           max_outstanding_io_per_volume, ValidFrom, ValidTo
+                    FROM dbo.ResourceGovernorConfigurationHistory
+                    WHERE InstanceID = @id
+                    ORDER BY ValidTo DESC
+                    """, cancellationToken, ("@id", id));
+
+                configHistory = historyRows.Select(row => (object)new
+                {
+                    isEnabled = Convert.ToBoolean(row["is_enabled"]),
+                    classifierFunction = row["classifier_function"]?.ToString(),
+                    reconfigurationError = Convert.ToBoolean(row["reconfiguration_error"]),
+                    reconfigurationPending = Convert.ToBoolean(row["reconfiguration_pending"]),
+                    maxOutstandingIoPerVolume = Convert.ToInt32(row["max_outstanding_io_per_volume"]),
+                    validFrom = row["ValidFrom"],
+                    validTo = row["ValidTo"],
+                }).ToList();
+            }
+            catch (Exception ex)
+            {
+                note = $"Resource Governor configuration unavailable: {ex.Message}";
+            }
+
+            try
+            {
+                var activePoolNames = (await sql.QueryAsync(
+                    "SELECT name FROM dbo.ResourceGovernorResourcePools WHERE InstanceID = @id AND IsActive = 1",
+                    cancellationToken, ("@id", id)))
+                    .Select(r => r["name"]?.ToString())
+                    .Where(n => n is not null)
+                    .ToHashSet();
+
+                var poolRows = await sql.QueryAsync(
+                    "EXEC dbo.ResourceGovernorResourcePools_Get @InstanceID = @id, @FromDate = @from, @ToDate = @to",
+                    cancellationToken, ("@id", id), ("@from", fromDate), ("@to", toDate));
+
+                pools = poolRows
+                    .Where(row => activePoolNames.Contains(row["name"]?.ToString()))
+                    .Select(row => (object)new
+                    {
+                        poolId = Convert.ToInt32(row["pool_id"]),
+                        name = row["name"]?.ToString(),
+                        minCpuPercent = Convert.ToInt32(row["min_cpu_percent"]),
+                        maxCpuPercent = Convert.ToInt32(row["max_cpu_percent"]),
+                        capCpuPercent = row["cap_cpu_percent"] is null ? (int?)null : Convert.ToInt32(row["cap_cpu_percent"]),
+                        minMemoryPercent = Convert.ToInt32(row["min_memory_percent"]),
+                        maxMemoryPercent = Convert.ToInt32(row["max_memory_percent"]),
+                        periodCpuPercent = ToNullableDouble(row["period_cpu_percent"]),
+                        periodCpuSharePercent = ToNullableDouble(row["period_cpu_share_percent"]),
+                        cpuCapUtilizationPercent = ToNullableDouble(row["cpu_cap_utilization_percent"]),
+                        cpuCapNearThresholdPercent = ToNullableDouble(row["cpu_cap_near_threshold_percent"]),
+                        usedMemoryKb = Convert.ToInt64(row["used_memory_kb"]),
+                        maxMemoryKb = Convert.ToInt64(row["max_memory_kb"]),
+                        targetMemoryKb = Convert.ToInt64(row["target_memory_kb"]),
+                        outOfMemoryCountTotal = Convert.ToInt64(row["out_of_memory_count"]),
+                        memGrantTimeoutCountTotal = Convert.ToInt64(row["total_memgrant_timeout_count"]),
+                        periodOutOfMemoryCountPerMin = ToNullableDouble(row["period_out_of_memory_count_per_min"]),
+                        periodMemGrantTimeoutCountPerMin = ToNullableDouble(row["period_memgrant_timeout_count_per_min"]),
+                        periodReadIoThrottledPerMin = ToNullableDouble(row["period_read_io_throttled_per_min"]),
+                        periodWriteIoThrottledPerMin = ToNullableDouble(row["period_write_io_throttled_per_min"]),
+                        snapshotDate = row["SnapshotDate"],
+                    })
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                note += (note.Length > 0 ? " " : string.Empty) + $"Resource pools unavailable: {ex.Message}";
+            }
+
+            try
+            {
+                var activeGroupNames = (await sql.QueryAsync(
+                    "SELECT name FROM dbo.ResourceGovernorWorkloadGroups WHERE InstanceID = @id AND IsActive = 1",
+                    cancellationToken, ("@id", id)))
+                    .Select(r => r["name"]?.ToString())
+                    .Where(n => n is not null)
+                    .ToHashSet();
+
+                var groupRows = await sql.QueryAsync(
+                    "EXEC dbo.ResourceGovernorWorkloadGroups_Get @InstanceID = @id, @FromDate = @from, @ToDate = @to",
+                    cancellationToken, ("@id", id), ("@from", fromDate), ("@to", toDate));
+
+                workloadGroups = groupRows
+                    .Where(row => activeGroupNames.Contains(row["name"]?.ToString()))
+                    .Select(row => (object)new
+                    {
+                        groupId = Convert.ToInt32(row["group_id"]),
+                        name = row["name"]?.ToString(),
+                        poolName = row["pool_name"]?.ToString(),
+                        importance = row["importance"]?.ToString(),
+                        requestMaxCpuTimeSec = Convert.ToInt32(row["request_max_cpu_time_sec"]),
+                        maxDop = Convert.ToInt32(row["max_dop"]),
+                        groupMaxRequests = Convert.ToInt32(row["group_max_requests"]),
+                        activeRequestCount = Convert.ToInt32(row["active_request_count"]),
+                        queuedRequestCount = Convert.ToInt32(row["queued_request_count"]),
+                        blockedTaskCount = Convert.ToInt32(row["blocked_task_count"]),
+                        periodCpuPercent = ToNullableDouble(row["period_cpu_percent"]),
+                        periodCpuSharePercent = ToNullableDouble(row["period_cpu_share_percent"]),
+                        periodRequestsPerMin = ToNullableDouble(row["period_requests_per_min"]),
+                        periodQueuedRequestCountPerMin = ToNullableDouble(row["period_queued_request_count_per_min"]),
+                        periodLockWaitsPerMin = ToNullableDouble(row["period_lock_waits_per_min"]),
+                        periodLockWaitTimeMsPerSec = ToNullableDouble(row["period_lock_wait_time_ms_per_sec"]),
+                        tempdbDataSpaceKb = row["tempdb_data_space_kb"] is null ? (long?)null : Convert.ToInt64(row["tempdb_data_space_kb"]),
+                        peakTempdbDataSpaceKb = row["peak_tempdb_data_space_kb"] is null ? (long?)null : Convert.ToInt64(row["peak_tempdb_data_space_kb"]),
+                        totalTempdbDataLimitViolationCount = row["total_tempdb_data_limit_violation_count"] is null ? (long?)null : Convert.ToInt64(row["total_tempdb_data_limit_violation_count"]),
+                        periodTempdbDataLimitViolationsPerMin = ToNullableDouble(row["period_tempdb_data_limit_violations_per_min"]),
+                        snapshotDate = row["SnapshotDate"],
+                    })
+                    .ToList();
+            }
+            catch (Exception ex)
+            {
+                note += (note.Length > 0 ? " " : string.Empty) + $"Workload groups unavailable: {ex.Message}";
+            }
+
+            return Results.Ok(new { config, configHistory, pools, workloadGroups, periodHours = effectiveHours, note });
+        }).RequireAuthorization();
+
+        return endpoints;
+    }
+
+    private static double? ToNullableDouble(object? value) => value is null or DBNull ? null : Convert.ToDouble(value);
+}

--- a/backend/Endpoints/SecurityEndpointMappings.cs
+++ b/backend/Endpoints/SecurityEndpointMappings.cs
@@ -1,0 +1,113 @@
+using System.Security.Claims;
+using DBADashWebView.Auth;
+using DBADashWebView.Data;
+
+namespace DBADashWebView.Endpoints;
+
+/// <summary>
+/// Surfaces DBA Dash's real security/audit collection that's currently completely unused:
+/// dbo.FailedLogins (parsed SQL error-log failed-login entries), dbo.KillSessionLog (audit
+/// trail of session-kill attempts made via DBA Dash's desktop client), and sysadmin fixed
+/// server-role membership from dbo.ServerPrincipals/dbo.ServerRoleMembers.
+///
+/// Deliberately read-only and deliberately scoped down: DBA Dash's own KillSessionLog feature
+/// is tied to a live "kill session" action that messages the collector agent over Service
+/// Broker - that's a real operational action with real risk, not requested, and not built here.
+/// Likewise dbo.ServerPermissions/DatabasePermissions (raw GRANT/DENY/REVOKE state) and
+/// DatabasePrincipals/DatabaseRoleMembers have no existing DBA Dash report to ground a query
+/// against, so they're left out rather than guessing at permission-resolution semantics.
+/// </summary>
+public static class SecurityEndpointMappings
+{
+    public static IEndpointRouteBuilder MapSecurityEndpoints(this IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapGet("/api/instances/{id:int}/security", async (int id, ClaimsPrincipal user, SqlDataService sql, CancellationToken cancellationToken) =>
+        {
+            var deny = await user.EnsureInstanceAccessAsync(id, sql, cancellationToken);
+            if (deny is not null) return deny;
+
+            string note = string.Empty;
+            object failedLogins = new { count = 0, firstLogDate = (object?)null, lastLogDate = (object?)null, recent = Array.Empty<object>() };
+            var killedSessions = new List<object>();
+            var sysadminMembers = new List<object>();
+
+            try
+            {
+                var summaryRows = await sql.QueryAsync(
+                    "SELECT COUNT(*) AS Cnt, MIN(LogDate) AS FirstLogDate, MAX(LogDate) AS LastLogDate FROM dbo.FailedLogins WHERE InstanceID = @id",
+                    cancellationToken, ("@id", id));
+
+                var recentRows = await sql.QueryAsync(
+                    "SELECT TOP 100 LogDate, Text FROM dbo.FailedLogins WHERE InstanceID = @id ORDER BY LogDate DESC",
+                    cancellationToken, ("@id", id));
+
+                var summary = summaryRows[0];
+                failedLogins = new
+                {
+                    count = Convert.ToInt32(summary["Cnt"]),
+                    firstLogDate = summary["FirstLogDate"],
+                    lastLogDate = summary["LastLogDate"],
+                    recent = recentRows.Select(row => (object)new
+                    {
+                        logDate = row["LogDate"],
+                        text = row["Text"]?.ToString(),
+                    }).ToList(),
+                };
+            }
+            catch (Exception ex)
+            {
+                note = $"Failed logins unavailable: {ex.Message}";
+            }
+
+            try
+            {
+                var rows = await sql.QueryAsync(
+                    "SELECT TOP 100 session_id, killed_by, log_date, status FROM dbo.KillSessionLog WHERE InstanceID = @id ORDER BY log_date DESC",
+                    cancellationToken, ("@id", id));
+
+                killedSessions = rows.Select(row => (object)new
+                {
+                    sessionId = Convert.ToInt32(row["session_id"]),
+                    killedBy = row["killed_by"]?.ToString(),
+                    logDate = row["log_date"],
+                    status = row["status"]?.ToString(),
+                }).ToList();
+            }
+            catch (Exception ex)
+            {
+                note += (note.Length > 0 ? " " : string.Empty) + $"Kill session log unavailable: {ex.Message}";
+            }
+
+            try
+            {
+                var rows = await sql.QueryAsync(
+                    """
+                    SELECT m.name AS MemberName, m.type_desc AS MemberType, m.is_disabled AS IsDisabled,
+                           m.create_date AS CreateDate, m.modify_date AS ModifyDate
+                    FROM dbo.ServerRoleMembers rm
+                    JOIN dbo.ServerPrincipals r ON rm.role_principal_id = r.principal_id AND r.InstanceID = rm.InstanceID
+                    JOIN dbo.ServerPrincipals m ON rm.member_principal_id = m.principal_id AND m.InstanceID = rm.InstanceID
+                    WHERE rm.InstanceID = @id AND r.name = 'sysadmin'
+                    ORDER BY m.name
+                    """, cancellationToken, ("@id", id));
+
+                sysadminMembers = rows.Select(row => (object)new
+                {
+                    memberName = row["MemberName"]?.ToString(),
+                    memberType = row["MemberType"]?.ToString(),
+                    isDisabled = Convert.ToBoolean(row["IsDisabled"]),
+                    createDate = row["CreateDate"],
+                    modifyDate = row["ModifyDate"],
+                }).ToList();
+            }
+            catch (Exception ex)
+            {
+                note += (note.Length > 0 ? " " : string.Empty) + $"Sysadmin membership unavailable: {ex.Message}";
+            }
+
+            return Results.Ok(new { failedLogins, killedSessions, sysadminMembers, note });
+        }).RequireAuthorization();
+
+        return endpoints;
+    }
+}

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -100,6 +100,7 @@ app.MapEstateEndpoints();
 app.MapReportEndpoints();
 app.MapCorruptionEndpoints();
 app.MapResourceGovernorEndpoints();
+app.MapSecurityEndpoints();
 
 app.MapFallbackToFile("index.html");
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -99,6 +99,7 @@ app.MapMonitoringEndpoints();
 app.MapEstateEndpoints();
 app.MapReportEndpoints();
 app.MapCorruptionEndpoints();
+app.MapResourceGovernorEndpoints();
 
 app.MapFallbackToFile("index.html");
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -38,7 +38,8 @@ builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
         };
     });
 builder.Services.AddAuthorizationBuilder()
-    .AddPolicy(AppPolicies.AdminOnly, policy => policy.RequireRole(AppRoles.Admin));
+    .AddPolicy(AppPolicies.AdminOnly, policy => policy.RequireRole(AppRoles.Admin))
+    .AddPolicy(AppPolicies.OperatorOrAdmin, policy => policy.RequireRole(AppRoles.Admin, AppRoles.Operator));
 
 builder.Services.AddCors(options => options.AddDefaultPolicy(policy =>
 {
@@ -97,6 +98,7 @@ app.MapPerformanceEndpoints();
 app.MapMonitoringEndpoints();
 app.MapEstateEndpoints();
 app.MapReportEndpoints();
+app.MapCorruptionEndpoints();
 
 app.MapFallbackToFile("index.html");
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ const BackupAmpelPage = lazy(() => import('./pages/BackupAmpelPage'));
 const SqlMonitorPage = lazy(() => import('./pages/SqlMonitorPage'));
 const AlertsPage = lazy(() => import('./pages/AlertsPage'));
 const DrivesPage = lazy(() => import('./pages/DrivesPage'));
+const CorruptionPage = lazy(() => import('./pages/CorruptionPage'));
 const AvailabilityGroupsPage = lazy(() => import('./pages/AvailabilityGroupsPage'));
 const DatabaseDetailPage = lazy(() => import('./pages/DatabaseDetailPage'));
 const AnalysisPage = lazy(() => import('./pages/AnalysisPage'));
@@ -298,6 +299,7 @@ export default function App() {
                   <Route path="/instances/:id/databases/:dbId" element={<DatabaseDetailPage />} />
                   <Route path="/instances/:id/backups" element={<BackupsPage />} />
                   <Route path="/instances/:id/drives" element={<DrivesPage />} />
+                  <Route path="/instances/:id/corruption" element={<CorruptionPage />} />
                   <Route path="/instances/:id/configuration" element={<ConfigurationPage />} />
                   <Route path="/instances/:id/hadr" element={<AvailabilityGroupsPage />} />
                   <Route path="/instances/:id/jobs" element={<JobTimelinePage />} />
@@ -306,6 +308,7 @@ export default function App() {
                   <Route path="/backups" element={<BackupsPage />} />
                   <Route path="/alerts" element={<AlertsPage />} />
                   <Route path="/drives" element={<DrivesPage />} />
+                  <Route path="/corruption" element={<CorruptionPage />} />
                   <Route path="/availability-groups" element={<AvailabilityGroupsPage />} />
                   <Route path="/analysis" element={<AnalysisPage />} />
                   <Route path="/queries" element={<QueriesPage />} />

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -25,6 +25,7 @@ import type {
   InstanceBackupRow,
   InstanceCpuBaselineResponse,
   ResourceGovernorResponse,
+  InstanceSecurityResponse,
   InstanceCpuRow,
   InstanceDatabaseRow,
   InstanceDetailResponse,
@@ -137,6 +138,7 @@ export const api = {
     request<InstanceCpuBaselineResponse>(`/api/instances/${id}/cpu/baseline?hours=${hours}&lookbackDays=${lookbackDays}`),
   instanceResourceGovernor: (id: number, hours = 24) =>
     request<ResourceGovernorResponse>(`/api/instances/${id}/resource-governor?hours=${hours}`),
+  instanceSecurity: (id: number) => request<InstanceSecurityResponse>(`/api/instances/${id}/security`),
   instanceWaits: (id: number, hours = 24) => request<InstanceWaitRow[]>(`/api/instances/${id}/waits?hours=${hours}`),
   instanceDrives: (id: number) => request<InstanceDriveRow[]>(`/api/instances/${id}/drives`),
   instanceDatabases: (id: number) => request<InstanceDatabaseRow[]>(`/api/instances/${id}/databases`),

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -24,6 +24,7 @@ import type {
   IdentityColumnRow,
   InstanceBackupRow,
   InstanceCpuBaselineResponse,
+  ResourceGovernorResponse,
   InstanceCpuRow,
   InstanceDatabaseRow,
   InstanceDetailResponse,
@@ -134,6 +135,8 @@ export const api = {
   instanceCpu: (id: number, hours = 24) => request<InstanceCpuRow[]>(`/api/instances/${id}/cpu?hours=${hours}`),
   instanceCpuBaseline: (id: number, hours = 24, lookbackDays = 14) =>
     request<InstanceCpuBaselineResponse>(`/api/instances/${id}/cpu/baseline?hours=${hours}&lookbackDays=${lookbackDays}`),
+  instanceResourceGovernor: (id: number, hours = 24) =>
+    request<ResourceGovernorResponse>(`/api/instances/${id}/resource-governor?hours=${hours}`),
   instanceWaits: (id: number, hours = 24) => request<InstanceWaitRow[]>(`/api/instances/${id}/waits?hours=${hours}`),
   instanceDrives: (id: number) => request<InstanceDriveRow[]>(`/api/instances/${id}/drives`),
   instanceDatabases: (id: number) => request<InstanceDatabaseRow[]>(`/api/instances/${id}/databases`),

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -9,6 +9,7 @@ import type {
   ApiErrorShape,
   ApiRow,
   AuthStatusResponse,
+  CorruptionRow,
   CreateLocalUserRequest,
   DbSpaceRow,
   EstateBackupRow,
@@ -22,6 +23,7 @@ import type {
   ExecStatsRow,
   IdentityColumnRow,
   InstanceBackupRow,
+  InstanceCpuBaselineResponse,
   InstanceCpuRow,
   InstanceDatabaseRow,
   InstanceDetailResponse,
@@ -41,6 +43,7 @@ import type {
   PerformanceCounterRow,
   PerformanceIOResponse,
   QueryAnalysisRow,
+  PlanForcingLogRow,
   QueryStoreRow,
   RunningQueryRow,
   SchemaChangeRow,
@@ -129,6 +132,8 @@ export const api = {
   instances: () => request<InstanceListRow[]>('/api/instances'),
   instance: (id: number) => request<InstanceDetailResponse>(`/api/instances/${id}`),
   instanceCpu: (id: number, hours = 24) => request<InstanceCpuRow[]>(`/api/instances/${id}/cpu?hours=${hours}`),
+  instanceCpuBaseline: (id: number, hours = 24, lookbackDays = 14) =>
+    request<InstanceCpuBaselineResponse>(`/api/instances/${id}/cpu/baseline?hours=${hours}&lookbackDays=${lookbackDays}`),
   instanceWaits: (id: number, hours = 24) => request<InstanceWaitRow[]>(`/api/instances/${id}/waits?hours=${hours}`),
   instanceDrives: (id: number) => request<InstanceDriveRow[]>(`/api/instances/${id}/drives`),
   instanceDatabases: (id: number) => request<InstanceDatabaseRow[]>(`/api/instances/${id}/databases`),
@@ -146,6 +151,10 @@ export const api = {
   instanceHadr: (id: number) => request<InstanceHadrResponse>(`/api/instances/${id}/hadr`),
   hadrOverview: () => request<HadrOverviewResponse>('/api/hadr/overview'),
   drives: () => request<EstateDriveRow[]>('/api/drives'),
+  corruption: (instanceId?: number) =>
+    request<{ data: CorruptionRow[] }>(`/api/corruption${instanceId ? `?instanceId=${instanceId}` : ''}`),
+  acknowledgeCorruption: (databaseId: number, clear: boolean) =>
+    request<{ success: boolean }>(`/api/corruption/${databaseId}/acknowledge`, { method: 'POST', body: JSON.stringify({ clear }) }),
   instanceQueries: (id: number) => request<QueryAnalysisRow[]>(`/api/instances/${id}/queries`),
   backupsEstate: () => request<EstateBackupRow[]>('/api/backups/estate'),
   backupsManagement: () => request<BackupManagementResponse>('/api/backups/management'),
@@ -193,6 +202,8 @@ export const api = {
     request<ApiDataResponse<SchemaChangeRow>>(`/api/monitoring/schema-changes?instanceId=${instanceId}&days=${days}`),
   performanceQueryStore: (instanceId: number) =>
     request<ApiDataResponse<QueryStoreRow>>(`/api/performance/query-store?instanceId=${instanceId}`),
+  performancePlanForcingLog: (instanceId: number) =>
+    request<ApiDataResponse<PlanForcingLogRow>>(`/api/performance/plan-forcing-log?instanceId=${instanceId}`),
   monitoringIdentityColumns: (instanceId: number) =>
     request<ApiDataResponse<IdentityColumnRow>>(`/api/monitoring/identity-columns?instanceId=${instanceId}`),
   monitoringTempDB: (instanceId: number) =>

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -26,6 +26,7 @@ import type {
   InstanceCpuBaselineResponse,
   ResourceGovernorResponse,
   InstanceSecurityResponse,
+  InstanceTableSizeResponse,
   InstanceCpuRow,
   InstanceDatabaseRow,
   InstanceDetailResponse,
@@ -41,6 +42,7 @@ import type {
   MemoryResponse,
   MonitoringConfigurationChangeRow,
   MonitoringConfigurationRow,
+  MonitoringTraceFlagRow,
   PatchingRow,
   PerformanceCounterRow,
   PerformanceIOResponse,
@@ -139,6 +141,8 @@ export const api = {
   instanceResourceGovernor: (id: number, hours = 24) =>
     request<ResourceGovernorResponse>(`/api/instances/${id}/resource-governor?hours=${hours}`),
   instanceSecurity: (id: number) => request<InstanceSecurityResponse>(`/api/instances/${id}/security`),
+  instanceTableSizes: (id: number, growthDays = 30, top = 100) =>
+    request<InstanceTableSizeResponse>(`/api/instances/${id}/table-sizes?growthDays=${growthDays}&top=${top}`),
   instanceWaits: (id: number, hours = 24) => request<InstanceWaitRow[]>(`/api/instances/${id}/waits?hours=${hours}`),
   instanceDrives: (id: number) => request<InstanceDriveRow[]>(`/api/instances/${id}/drives`),
   instanceDatabases: (id: number) => request<InstanceDatabaseRow[]>(`/api/instances/${id}/databases`),
@@ -201,6 +205,8 @@ export const api = {
     request<ApiDataResponse<MonitoringConfigurationRow>>(`/api/monitoring/configuration?instanceId=${instanceId}`),
   monitoringConfigurationChanges: (instanceId: number, days = 30) =>
     request<ApiDataResponse<MonitoringConfigurationChangeRow>>(`/api/monitoring/configuration/changes?instanceId=${instanceId}&days=${days}`),
+  monitoringTraceFlags: (instanceId: number) =>
+    request<ApiDataResponse<MonitoringTraceFlagRow>>(`/api/monitoring/trace-flags?instanceId=${instanceId}`),
   monitoringPatching: () =>
     request<ApiDataResponse<PatchingRow>>('/api/monitoring/patching'),
   monitoringSchemaChanges: (instanceId: number, days = 30) =>

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -98,6 +98,18 @@ export interface InstanceCpuRow extends ApiRow {
   TotalCPU?: number | null;
 }
 
+export interface InstanceCpuBaselinePoint extends ApiRow {
+  MinuteOfDay: number;
+  AvgCpu: number | null;
+  SampleCount: number;
+}
+
+export interface InstanceCpuBaselineResponse {
+  data: InstanceCpuBaselinePoint[];
+  bucketMinutes: number;
+  error?: string;
+}
+
 export interface InstanceWaitRow extends ApiRow {
   WaitTypeID?: number | null;
   WaitType?: string | null;
@@ -307,6 +319,19 @@ export interface EstateBackupRow extends ApiRow {
   fullBackupSize?: number | null;
   diffBackupDate?: string | null;
   logBackupDate?: string | null;
+}
+
+export interface CorruptionRow {
+  databaseId: number;
+  databaseName?: string | null;
+  instanceId: number;
+  instanceDisplayName?: string | null;
+  sourceTable: number;
+  source: string;
+  updateDate: string;
+  ackDate?: string | null;
+  isAcknowledged: boolean;
+  countOfRows?: number | null;
 }
 
 export interface EstateDriveRow extends ApiRow {
@@ -697,6 +722,21 @@ export interface QueryStoreRow extends ApiRow {
   avgDuration?: number | null;
   countExecutions?: number | null;
   avgLogicalIoReads?: number | null;
+}
+
+export interface PlanForcingLogRow extends ApiRow {
+  MessageGroupID: string;
+  InstanceID: number;
+  database_name: string;
+  log_date: string;
+  log_type: string;
+  user_name: string;
+  query_id: number;
+  plan_id: number;
+  object_name?: string | null;
+  query_sql_text?: string | null;
+  notes?: string | null;
+  status?: string | null;
 }
 
 export interface SchemaChangeRow extends ApiRow {

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -334,6 +334,76 @@ export interface CorruptionRow {
   countOfRows?: number | null;
 }
 
+export interface ResourceGovernorConfig {
+  isEnabled: boolean;
+  classifierFunction?: string | null;
+  reconfigurationError: boolean;
+  reconfigurationPending: boolean;
+  maxOutstandingIoPerVolume: number;
+  validFrom: string;
+}
+
+export interface ResourceGovernorConfigHistoryEntry extends ResourceGovernorConfig {
+  validTo: string;
+}
+
+export interface ResourceGovernorPool {
+  poolId: number;
+  name: string;
+  minCpuPercent: number;
+  maxCpuPercent: number;
+  capCpuPercent?: number | null;
+  minMemoryPercent: number;
+  maxMemoryPercent: number;
+  periodCpuPercent?: number | null;
+  periodCpuSharePercent?: number | null;
+  cpuCapUtilizationPercent?: number | null;
+  cpuCapNearThresholdPercent?: number | null;
+  usedMemoryKb: number;
+  maxMemoryKb: number;
+  targetMemoryKb: number;
+  outOfMemoryCountTotal: number;
+  memGrantTimeoutCountTotal: number;
+  periodOutOfMemoryCountPerMin?: number | null;
+  periodMemGrantTimeoutCountPerMin?: number | null;
+  periodReadIoThrottledPerMin?: number | null;
+  periodWriteIoThrottledPerMin?: number | null;
+  snapshotDate: string;
+}
+
+export interface ResourceGovernorWorkloadGroup {
+  groupId: number;
+  name: string;
+  poolName: string;
+  importance: string;
+  requestMaxCpuTimeSec: number;
+  maxDop: number;
+  groupMaxRequests: number;
+  activeRequestCount: number;
+  queuedRequestCount: number;
+  blockedTaskCount: number;
+  periodCpuPercent?: number | null;
+  periodCpuSharePercent?: number | null;
+  periodRequestsPerMin?: number | null;
+  periodQueuedRequestCountPerMin?: number | null;
+  periodLockWaitsPerMin?: number | null;
+  periodLockWaitTimeMsPerSec?: number | null;
+  tempdbDataSpaceKb?: number | null;
+  peakTempdbDataSpaceKb?: number | null;
+  totalTempdbDataLimitViolationCount?: number | null;
+  periodTempdbDataLimitViolationsPerMin?: number | null;
+  snapshotDate: string;
+}
+
+export interface ResourceGovernorResponse {
+  config: ResourceGovernorConfig | null;
+  configHistory: ResourceGovernorConfigHistoryEntry[];
+  pools: ResourceGovernorPool[];
+  workloadGroups: ResourceGovernorWorkloadGroup[];
+  periodHours: number;
+  note?: string;
+}
+
 export interface EstateDriveRow extends ApiRow {
   DriveID?: number | null;
   InstanceID?: number | null;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -404,6 +404,38 @@ export interface ResourceGovernorResponse {
   note?: string;
 }
 
+export interface FailedLoginEntry {
+  logDate: string;
+  text?: string | null;
+}
+
+export interface KilledSessionEntry {
+  sessionId: number;
+  killedBy?: string | null;
+  logDate: string;
+  status?: string | null;
+}
+
+export interface SysadminMemberEntry {
+  memberName: string;
+  memberType?: string | null;
+  isDisabled: boolean;
+  createDate?: string | null;
+  modifyDate?: string | null;
+}
+
+export interface InstanceSecurityResponse {
+  failedLogins: {
+    count: number;
+    firstLogDate?: string | null;
+    lastLogDate?: string | null;
+    recent: FailedLoginEntry[];
+  };
+  killedSessions: KilledSessionEntry[];
+  sysadminMembers: SysadminMemberEntry[];
+  note?: string;
+}
+
 export interface EstateDriveRow extends ApiRow {
   DriveID?: number | null;
   InstanceID?: number | null;

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -216,11 +216,36 @@ export interface InstanceHadrDatabaseRow extends ApiRow {
   DatabaseName?: string | null;
 }
 
+export interface InstanceMirroringRow extends ApiRow {
+  DatabaseID: number;
+  DatabaseName?: string | null;
+  mirroring_state_desc?: string | null;
+  mirroring_role_desc?: string | null;
+  mirroring_safety_level_desc?: string | null;
+  mirroring_partner_name?: string | null;
+  mirroring_partner_instance?: string | null;
+  mirroring_witness_name?: string | null;
+  mirroring_witness_state_desc?: string | null;
+  mirroring_redo_queue?: number | null;
+  mirroring_redo_queue_type?: string | null;
+  PartnerStateDesc?: string | null;
+}
+
+export interface InstanceLogShippingRow extends ApiRow {
+  DatabaseID: number;
+  DatabaseName?: string | null;
+  restore_date?: string | null;
+  backup_start_date?: string | null;
+  last_file?: string | null;
+}
+
 export interface InstanceHadrResponse {
   error?: string;
   ags: InstanceHadrGroupRow[];
   replicas: InstanceHadrReplicaRow[];
   databases: InstanceHadrDatabaseRow[];
+  mirroring: InstanceMirroringRow[];
+  logShipping: InstanceLogShippingRow[];
 }
 
 export interface HadrOverviewGroupRow extends ApiRow {
@@ -434,6 +459,29 @@ export interface InstanceSecurityResponse {
   killedSessions: KilledSessionEntry[];
   sysadminMembers: SysadminMemberEntry[];
   note?: string;
+}
+
+export interface InstanceTableSizeRow extends ApiRow {
+  ObjectID: number;
+  DatabaseID: number;
+  DatabaseName?: string | null;
+  SchemaName?: string | null;
+  ObjectName?: string | null;
+  SnapshotDate: string;
+  Rows: number;
+  ReservedKb: number;
+  UsedKb: number;
+  DataKb: number;
+  IndexKb: number;
+  AvgRowsPerDay?: number | null;
+  AvgKbPerDay?: number | null;
+  CalcDays?: number | null;
+}
+
+export interface InstanceTableSizeResponse {
+  data: InstanceTableSizeRow[];
+  growthDays: number;
+  error?: string;
 }
 
 export interface EstateDriveRow extends ApiRow {
@@ -679,6 +727,11 @@ export interface MonitoringConfigurationChangeRow extends ApiRow {
   old_value?: string | number | boolean | null;
   new_value?: string | number | boolean | null;
   ChangeDate?: string | null;
+}
+
+export interface MonitoringTraceFlagRow extends ApiRow {
+  TraceFlag: number;
+  ValidFrom?: string | null;
 }
 
 export interface QueryAnalysisRow extends ApiRow {

--- a/frontend/src/components/NavMenu.tsx
+++ b/frontend/src/components/NavMenu.tsx
@@ -17,6 +17,7 @@ import {
   Play,
   Settings,
   Shield,
+  ShieldAlert,
   Wrench,
   Info,
 } from 'lucide-react';
@@ -74,6 +75,7 @@ const navGroups: NavGroup[] = [
       { label: 'Configuration', path: '/monitoring/configuration', icon: Settings },
       { label: 'Patching', path: '/monitoring/patching', icon: Wrench },
       { label: 'Schema Changes', path: '/monitoring/schema-changes', icon: Blocks },
+      { label: 'Corruption', path: '/corruption', icon: ShieldAlert },
       { label: 'Identity Columns', path: '/monitoring/identity-columns', icon: Database },
       { label: 'TempDB', path: '/monitoring/tempdb', icon: Database },
       { label: 'DB Space', path: '/monitoring/db-space', icon: HardDrive },

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo } from 'react';
 import { api } from '../api/api';
-import type { ApiRow, InstanceCpuRow, InstanceListRow, InstanceWaitRow } from '../api/types';
+import type { ApiRow, InstanceCpuBaselinePoint, InstanceCpuRow, InstanceListRow, InstanceWaitRow } from '../api/types';
 import { useRefresh } from '../App';
 import LoadingSpinner from '../components/LoadingSpinner';
 import EmptyState from '../components/EmptyState';
@@ -8,6 +8,22 @@ import {
   ComposedChart, Line, Area, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
   ResponsiveContainer, Brush, ReferenceLine
 } from 'recharts';
+
+const BASELINE_LOOKBACK_DAYS = 14;
+// Below this, the "14-day average" bucket is really a 1-2 sample average -
+// not worth presenting as a baseline yet.
+const MIN_SAMPLE_COUNT_FOR_BASELINE = 3;
+
+function findBaselinePoint(
+  eventTimeIso: string,
+  bucketMinutes: number,
+  baseline: InstanceCpuBaselinePoint[]
+): InstanceCpuBaselinePoint | undefined {
+  const d = new Date(eventTimeIso);
+  const minuteOfDay = d.getUTCHours() * 60 + d.getUTCMinutes();
+  const bucket = Math.floor(minuteOfDay / bucketMinutes) * bucketMinutes;
+  return baseline.find(p => p.MinuteOfDay === bucket);
+}
 
 interface AlertTimelineRow extends ApiRow {
   EventTime?: string | null;
@@ -24,6 +40,9 @@ export default function AnalysisPage() {
   const [loading, setLoading] = useState(true);
   const [metrics, setMetrics] = useState({ cpu: true, ioWaits: false, memory: false });
   const [showBaseline, setShowBaseline] = useState(false);
+  const [baselineData, setBaselineData] = useState<InstanceCpuBaselinePoint[]>([]);
+  const [baselineBucketMinutes, setBaselineBucketMinutes] = useState(15);
+  const [baselineLoading, setBaselineLoading] = useState(false);
 
   useEffect(() => {
     api.instances().then(d => {
@@ -47,17 +66,40 @@ export default function AnalysisPage() {
     }).finally(() => setLoading(false));
   }, [selectedInstance, lastRefresh]);
 
+  useEffect(() => {
+    if (!selectedInstance || !showBaseline) return;
+    setBaselineLoading(true);
+    api.instanceCpuBaseline(selectedInstance, 24, BASELINE_LOOKBACK_DAYS)
+      .then(res => {
+        setBaselineData(Array.isArray(res.data) ? res.data : []);
+        setBaselineBucketMinutes(res.bucketMinutes || 15);
+      })
+      .catch(() => setBaselineData([]))
+      .finally(() => setBaselineLoading(false));
+  }, [selectedInstance, showBaseline, lastRefresh]);
+
   const chartData = useMemo(() => {
-    return cpuData.map((c, i) => ({
-      time: new Date(c.EventTime).toLocaleTimeString(),
-      fullTime: c.EventTime,
-      cpu: c.SQLProcessCPU ?? 0,
-      totalCpu: c.TotalCPU ?? 0,
-      ioWaits: waitsData.length > 0 ? (waitsData[0]?.TotalWaitMs ?? 0) / Math.max(cpuData.length, 1) : 0,
-      memory: c.TotalCPU ? Math.min(c.TotalCPU * 0.7 + 10, 100) : 0,
-      baselineCpu: showBaseline ? Math.max(0, (c.SQLProcessCPU ?? 0) + (Math.sin(i * 0.1) * 15)) : undefined,
-    })).reverse();
-  }, [cpuData, waitsData, showBaseline]);
+    return cpuData.map((c) => {
+      const baselinePoint = showBaseline ? findBaselinePoint(c.EventTime, baselineBucketMinutes, baselineData) : undefined;
+      const baselineCpu = baselinePoint && baselinePoint.SampleCount >= MIN_SAMPLE_COUNT_FOR_BASELINE
+        ? baselinePoint.AvgCpu ?? undefined
+        : undefined;
+      return {
+        time: new Date(c.EventTime).toLocaleTimeString(),
+        fullTime: c.EventTime,
+        cpu: c.SQLProcessCPU ?? 0,
+        totalCpu: c.TotalCPU ?? 0,
+        ioWaits: waitsData.length > 0 ? (waitsData[0]?.TotalWaitMs ?? 0) / Math.max(cpuData.length, 1) : 0,
+        memory: c.TotalCPU ? Math.min(c.TotalCPU * 0.7 + 10, 100) : 0,
+        baselineCpu,
+      };
+    }).reverse();
+  }, [cpuData, waitsData, showBaseline, baselineData, baselineBucketMinutes]);
+
+  const baselineHasEnoughHistory = useMemo(
+    () => baselineData.some(p => p.SampleCount >= MIN_SAMPLE_COUNT_FOR_BASELINE),
+    [baselineData]
+  );
 
   const alertTimes = useMemo(() => {
     return alerts
@@ -108,9 +150,17 @@ export default function AnalysisPage() {
               onChange={() => setShowBaseline(b => !b)}
               className="rounded bg-white/10 border-white/20"
             />
-            Baseline (last week)
+            Baseline ({BASELINE_LOOKBACK_DAYS}-day avg)
+            {baselineLoading && <span className="text-xs text-gray-500">loading…</span>}
           </label>
         </div>
+
+        {showBaseline && !baselineLoading && !baselineHasEnoughHistory && (
+          <p className="text-xs text-amber-400/80 mb-3">
+            Not enough collected history yet for a baseline — needs at least a few samples per 15-minute
+            time-of-day bucket from the last {BASELINE_LOOKBACK_DAYS} days.
+          </p>
+        )}
 
         {chartData.length === 0 ? (
           <EmptyState message="No performance data available for this instance." />

--- a/frontend/src/pages/AvailabilityGroupsPage.tsx
+++ b/frontend/src/pages/AvailabilityGroupsPage.tsx
@@ -7,6 +7,8 @@ import type {
   InstanceHadrGroupRow,
   InstanceHadrReplicaRow,
   InstanceHadrResponse,
+  InstanceMirroringRow,
+  InstanceLogShippingRow,
 } from '../api/types';
 import LoadingSpinner from '../components/LoadingSpinner';
 import EmptyState from '../components/EmptyState';
@@ -14,7 +16,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import clsx from 'clsx';
 import {
   Shield, Server, Database, ArrowRight, ArrowDown, ChevronDown, ChevronRight,
-  Activity, AlertTriangle, Network, Crown, RefreshCw, Search, X
+  Activity, AlertTriangle, Network, Crown, RefreshCw, Search, X, Copy, History
 } from 'lucide-react';
 
 /* ── helpers ── */
@@ -45,6 +47,16 @@ function syncStateBadge(state: string | null | undefined): string {
   if (s === 'SYNCHRONIZING') return 'bg-blue-500/20 text-blue-300';
   if (s === 'NOT SYNCHRONIZING') return 'bg-red-500/20 text-red-300';
   if (s === 'REVERTING') return 'bg-yellow-500/20 text-yellow-300';
+  return 'bg-gray-500/20 text-gray-400';
+}
+
+function mirroringStateBadge(state: string | null | undefined): string {
+  if (!state) return 'bg-gray-500/20 text-gray-400';
+  const s = state.toUpperCase();
+  if (s === 'SYNCHRONIZED') return 'bg-green-500/20 text-green-300';
+  if (s === 'SYNCHRONIZING') return 'bg-blue-500/20 text-blue-300';
+  if (s === 'PENDING_FAILOVER') return 'bg-yellow-500/20 text-yellow-300';
+  if (s === 'SUSPENDED' || s === 'DISCONNECTED' || s === 'UNSYNCHRONIZED') return 'bg-red-500/20 text-red-300';
   return 'bg-gray-500/20 text-gray-400';
 }
 
@@ -322,7 +334,83 @@ function InstanceHadrView({ instanceId }: { instanceId: number }) {
   if (loading) return <LoadingSpinner />;
   if (!data || data.error) return <EmptyState message={data?.error || 'Failed to load HA/DR data'} />;
 
-  const { ags = [], replicas = [], databases = [] } = data;
+  const { ags = [], replicas = [], databases = [], mirroring = [], logShipping = [] } = data;
+
+  const mirroringAndLogShippingSections = (
+    <>
+      {mirroring.length > 0 && (
+        <div className="glass rounded-xl overflow-hidden">
+          <div className="px-4 py-3 bg-slate-800/80 flex items-center gap-2 text-xs text-gray-400 uppercase tracking-wider">
+            <Copy className="w-3.5 h-3.5 text-purple-400" /> Database Mirroring
+          </div>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 border-b border-white/5">
+                <th className="px-4 py-2">Database</th>
+                <th className="px-4 py-2">Role</th>
+                <th className="px-4 py-2">State</th>
+                <th className="px-4 py-2">Partner</th>
+                <th className="px-4 py-2">Witness</th>
+                <th className="px-4 py-2">Safety</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {mirroring.map((m: InstanceMirroringRow) => (
+                <tr key={m.DatabaseID} className="hover:bg-white/5">
+                  <td className="px-4 py-2.5 text-white font-medium">{m.DatabaseName}</td>
+                  <td className="px-4 py-2.5 text-gray-300">{m.mirroring_role_desc || '—'}</td>
+                  <td className="px-4 py-2.5">
+                    <span className={clsx('px-2 py-0.5 rounded-full text-xs', mirroringStateBadge(m.mirroring_state_desc))}>
+                      {m.mirroring_state_desc || 'UNKNOWN'}
+                    </span>
+                    {m.PartnerStateDesc && m.PartnerStateDesc !== m.mirroring_state_desc && (
+                      <span className="text-xs text-gray-500 ml-1">(partner: {m.PartnerStateDesc})</span>
+                    )}
+                  </td>
+                  <td className="px-4 py-2.5 text-gray-400 text-xs">{m.mirroring_partner_instance || m.mirroring_partner_name || '—'}</td>
+                  <td className="px-4 py-2.5 text-gray-400 text-xs">{m.mirroring_witness_name || '—'}</td>
+                  <td className="px-4 py-2.5 text-gray-400 text-xs">{m.mirroring_safety_level_desc || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {logShipping.length > 0 && (
+        <div className="glass rounded-xl overflow-hidden">
+          <div className="px-4 py-3 bg-slate-800/80 flex items-center gap-2 text-xs text-gray-400 uppercase tracking-wider">
+            <History className="w-3.5 h-3.5 text-cyan-400" /> Log Shipping
+          </div>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left text-xs text-gray-500 border-b border-white/5">
+                <th className="px-4 py-2">Database</th>
+                <th className="px-4 py-2">Last Restore</th>
+                <th className="px-4 py-2">Last Backup Restored</th>
+                <th className="px-4 py-2">Last File</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {logShipping.map((l: InstanceLogShippingRow) => {
+                const staleHours = l.restore_date ? (Date.now() - new Date(l.restore_date).getTime()) / 3600000 : null;
+                return (
+                  <tr key={l.DatabaseID} className="hover:bg-white/5">
+                    <td className="px-4 py-2.5 text-white font-medium">{l.DatabaseName}</td>
+                    <td className={clsx('px-4 py-2.5 text-xs', staleHours == null ? 'text-gray-500' : staleHours > 4 ? 'text-red-400' : staleHours > 1 ? 'text-yellow-400' : 'text-emerald-400')}>
+                      {l.restore_date ? new Date(l.restore_date).toLocaleString() : '—'}
+                    </td>
+                    <td className="px-4 py-2.5 text-gray-400 text-xs">{l.backup_start_date ? new Date(l.backup_start_date).toLocaleString() : '—'}</td>
+                    <td className="px-4 py-2.5 text-gray-500 text-xs font-mono truncate max-w-[240px]">{l.last_file || '—'}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
 
   if (ags.length === 0) return (
     <div className="space-y-4">
@@ -335,7 +423,11 @@ function InstanceHadrView({ instanceId }: { instanceId: number }) {
         </span>
       </div>
       </div>
-      <EmptyState message="No Availability Groups configured on this instance" />
+      {mirroring.length === 0 && logShipping.length === 0 ? (
+        <EmptyState message="No Availability Groups, Database Mirroring, or Log Shipping configured on this instance" />
+      ) : (
+        mirroringAndLogShippingSections
+      )}
     </div>
   );
 
@@ -538,6 +630,8 @@ function InstanceHadrView({ instanceId }: { instanceId: number }) {
           </div>
         );
       })}
+
+      {(mirroring.length > 0 || logShipping.length > 0) && mirroringAndLogShippingSections}
     </div>
   );
 }

--- a/frontend/src/pages/ConfigurationPage.tsx
+++ b/frontend/src/pages/ConfigurationPage.tsx
@@ -5,6 +5,7 @@ import type {
   InstanceListRow,
   MonitoringConfigurationChangeRow,
   MonitoringConfigurationRow,
+  MonitoringTraceFlagRow,
 } from '../api/types';
 import LoadingSpinner from '../components/LoadingSpinner';
 import { motion } from 'framer-motion';
@@ -19,12 +20,14 @@ export default function ConfigurationPage() {
   const { id: routeId } = useParams();
   const [config, setConfig] = useState<MonitoringConfigurationRow[]>([]);
   const [changes, setChanges] = useState<MonitoringConfigurationChangeRow[]>([]);
+  const [traceFlags, setTraceFlags] = useState<MonitoringTraceFlagRow[]>([]);
   const [configNote, setConfigNote] = useState('');
   const [changesNote, setChangesNote] = useState('');
+  const [traceFlagsNote, setTraceFlagsNote] = useState('');
   const [loading, setLoading] = useState(true);
   const [instances, setInstances] = useState<InstanceListRow[]>([]);
   const [selectedInstance, setSelectedInstance] = useState<number | undefined>(routeId ? Number(routeId) : undefined);
-  const [tab, setTab] = useState<'current' | 'changes'>('current');
+  const [tab, setTab] = useState<'current' | 'changes' | 'trace-flags'>('current');
   const [search, setSearch] = useState('');
 
   useEffect(() => {
@@ -32,16 +35,19 @@ export default function ConfigurationPage() {
   }, []);
 
   useEffect(() => {
-    if (!selectedInstance) { setConfig([]); setChanges([]); setLoading(false); return; }
+    if (!selectedInstance) { setConfig([]); setChanges([]); setTraceFlags([]); setLoading(false); return; }
     setLoading(true);
     Promise.all([
       api.monitoringConfiguration(selectedInstance).catch(() => ({ data: [], note: '' })),
       api.monitoringConfigurationChanges(selectedInstance).catch(() => ({ data: [], note: '' })),
-    ]).then(([cfg, chg]) => {
+      api.monitoringTraceFlags(selectedInstance).catch(() => ({ data: [], note: '' })),
+    ]).then(([cfg, chg, tf]) => {
       setConfig(Array.isArray(cfg.data) ? cfg.data : []);
       setConfigNote(cfg.note || '');
       setChanges(Array.isArray(chg.data) ? chg.data : []);
       setChangesNote(chg.note || '');
+      setTraceFlags(Array.isArray(tf.data) ? tf.data : []);
+      setTraceFlagsNote(tf.note || '');
     }).finally(() => setLoading(false));
   }, [selectedInstance]);
 
@@ -86,10 +92,14 @@ export default function ConfigurationPage() {
             <button onClick={() => setTab('changes')} className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${tab === 'changes' ? 'bg-indigo-500/20 text-indigo-400' : 'text-gray-400 hover:text-white hover:bg-slate-800/50'}`}>
               Changes {changes.length > 0 && <span className="ml-1 px-1.5 py-0.5 rounded-full text-xs bg-indigo-500/30">{changes.length}</span>}
             </button>
+            <button onClick={() => setTab('trace-flags')} className={`px-4 py-2 rounded-lg text-sm font-medium transition-all ${tab === 'trace-flags' ? 'bg-indigo-500/20 text-indigo-400' : 'text-gray-400 hover:text-white hover:bg-slate-800/50'}`}>
+              Trace Flags {traceFlags.length > 0 && <span className="ml-1 px-1.5 py-0.5 rounded-full text-xs bg-indigo-500/30">{traceFlags.length}</span>}
+            </button>
           </div>
 
           {configNote && <div className="glass-card p-3 text-xs text-yellow-400">{configNote}</div>}
           {tab === 'changes' && changesNote && <div className="glass-card p-3 text-xs text-yellow-400">{changesNote}</div>}
+          {tab === 'trace-flags' && traceFlagsNote && <div className="glass-card p-3 text-xs text-yellow-400">{traceFlagsNote}</div>}
 
           {tab === 'current' && (
             <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="glass-card overflow-hidden">
@@ -158,6 +168,34 @@ export default function ConfigurationPage() {
                       </tr>
                     ))}
                     {changes.length === 0 && <tr><td colSpan={4} className="px-3 py-8 text-center text-gray-500">No configuration changes detected</td></tr>}
+                  </tbody>
+                </table>
+              </div>
+            </motion.div>
+          )}
+
+          {tab === 'trace-flags' && (
+            <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} className="glass-card overflow-hidden">
+              <div className="p-4 border-b border-white/10">
+                <h2 className="text-lg font-semibold text-white">Enabled Trace Flags</h2>
+                <p className="text-xs text-gray-500 mt-0.5">Server-level DBCC TRACEON flags currently set (dbo.TraceFlags)</p>
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead className="border-b border-white/10">
+                    <tr>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-400">Trace Flag</th>
+                      <th className="px-3 py-2 text-left text-xs font-medium text-gray-400">Set Since</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {traceFlags.map((row, i) => (
+                      <tr key={i} className="border-b border-white/5 hover:bg-slate-800/50">
+                        <td className="px-3 py-2 text-white font-medium font-mono">{row.TraceFlag}</td>
+                        <td className="px-3 py-2 text-gray-400">{row.ValidFrom ? new Date(row.ValidFrom).toLocaleString() : '-'}</td>
+                      </tr>
+                    ))}
+                    {traceFlags.length === 0 && <tr><td colSpan={2} className="px-3 py-8 text-center text-gray-500">No trace flags currently set</td></tr>}
                   </tbody>
                 </table>
               </div>

--- a/frontend/src/pages/CorruptionPage.tsx
+++ b/frontend/src/pages/CorruptionPage.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { api } from '../api/api';
+import type { CorruptionRow } from '../api/types';
+import { useRefresh } from '../App';
+import { hasRole } from '../auth/session';
+import LoadingSpinner from '../components/LoadingSpinner';
+import EmptyState from '../components/EmptyState';
+import { ShieldAlert, ShieldCheck, Check } from 'lucide-react';
+import { format } from 'date-fns';
+import { clsx } from 'clsx';
+
+export default function CorruptionPage() {
+  const { id } = useParams();
+  const { lastRefresh } = useRefresh();
+  const [rows, setRows] = useState<CorruptionRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [ackingId, setAckingId] = useState<number | null>(null);
+  const canAcknowledge = hasRole(['Admin', 'Operator']);
+
+  const load = () => {
+    setLoading(true);
+    api.corruption(id ? Number(id) : undefined)
+      .then(res => setRows(Array.isArray(res.data) ? res.data : []))
+      .catch(() => setRows([]))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(load, [id, lastRefresh]);
+
+  const acknowledge = async (databaseId: number) => {
+    setAckingId(databaseId);
+    try {
+      await api.acknowledgeCorruption(databaseId, false);
+      load();
+    } finally {
+      setAckingId(null);
+    }
+  };
+
+  if (loading) return <LoadingSpinner />;
+
+  const openCount = rows.filter(r => !r.isAcknowledged).length;
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h1 className="text-2xl font-bold text-white flex items-center gap-2">
+          <ShieldAlert className="w-6 h-6 text-red-400" /> {id ? 'Instance Corruption Findings' : 'Corruption Findings'}
+        </h1>
+        <p className="text-sm text-gray-400 mt-0.5">
+          Real consistency-check findings from msdb.suspect_pages and the mirroring/HADR auto-page-repair
+          history (dbo.Corruption) — {rows.length} finding{rows.length !== 1 ? 's' : ''}
+          {openCount > 0 && <span className="text-red-400"> · {openCount} unacknowledged</span>}
+        </p>
+      </div>
+
+      {rows.length === 0 ? (
+        <EmptyState message="No corruption findings recorded." />
+      ) : (
+        <div className="glass rounded-xl overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-slate-800/80 text-left text-xs text-gray-400 uppercase tracking-wider">
+                {!id && <th className="px-4 py-3">Instance</th>}
+                <th className="px-4 py-3">Database</th>
+                <th className="px-4 py-3">Source</th>
+                <th className="px-4 py-3 text-right">Rows</th>
+                <th className="px-4 py-3">Detected</th>
+                <th className="px-4 py-3">Status</th>
+                {canAcknowledge && <th className="px-4 py-3 text-right">Actions</th>}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-white/5">
+              {rows.map(r => (
+                <tr key={`${r.databaseId}-${r.sourceTable}`} className={clsx('hover:bg-white/5 transition-colors', !r.isAcknowledged && 'bg-red-500/5')}>
+                  {!id && <td className="px-4 py-2.5 text-gray-300">{r.instanceDisplayName || '—'}</td>}
+                  <td className="px-4 py-2.5 text-white font-medium">{r.databaseName || '—'}</td>
+                  <td className="px-4 py-2.5 text-gray-300 text-xs">{r.source}</td>
+                  <td className="px-4 py-2.5 text-right text-gray-300">{r.countOfRows ?? '—'}</td>
+                  <td className="px-4 py-2.5 text-gray-400 text-xs">{r.updateDate ? format(new Date(r.updateDate), 'yyyy-MM-dd HH:mm') : '—'}</td>
+                  <td className="px-4 py-2.5">
+                    {r.isAcknowledged ? (
+                      <span className="inline-flex items-center gap-1 text-xs text-emerald-400">
+                        <ShieldCheck className="w-3.5 h-3.5" /> Acknowledged
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1 text-xs text-red-400">
+                        <ShieldAlert className="w-3.5 h-3.5" /> Open
+                      </span>
+                    )}
+                  </td>
+                  {canAcknowledge && (
+                    <td className="px-4 py-2.5 text-right">
+                      {!r.isAcknowledged && (
+                        <button
+                          onClick={() => acknowledge(r.databaseId)}
+                          disabled={ackingId === r.databaseId}
+                          className="inline-flex items-center gap-1 text-xs px-2.5 py-1 rounded-lg bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 hover:bg-emerald-500/20 disabled:opacity-50 transition-colors"
+                        >
+                          <Check className="w-3 h-3" /> {ackingId === r.databaseId ? 'Acknowledging…' : 'Acknowledge'}
+                        </button>
+                      )}
+                    </td>
+                  )}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/InstanceDetailPage.tsx
+++ b/frontend/src/pages/InstanceDetailPage.tsx
@@ -10,6 +10,7 @@ import type {
   InstanceDriveRow,
   InstanceJobRow,
   InstanceWaitRow,
+  ResourceGovernorResponse,
 } from '../api/types';
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, BarChart, Bar, Legend } from 'recharts';
 import StatusBadge from '../components/StatusBadge';
@@ -20,7 +21,7 @@ import EmptyState from '../components/EmptyState';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Server, Cpu, HardDrive, Database, Activity, Clock, Shield,
-  ChevronRight, Zap, BarChart3, Timer, AlertTriangle
+  ChevronRight, Zap, BarChart3, Timer, AlertTriangle, Gauge, Layers
 } from 'lucide-react';
 import TimeRangeSelector, { hoursLabel } from '../components/TimeRangeSelector';
 import { clsx } from 'clsx';
@@ -43,6 +44,23 @@ function formatBytes(b: number | null | undefined) {
 }
 
 const recoveryLabel = (rm: number) => rm === 1 ? 'Full' : rm === 2 ? 'Bulk-Logged' : rm === 3 ? 'Simple' : '—';
+
+function formatKb(kb: number | null | undefined) {
+  if (kb === null || kb === undefined) return '—';
+  if (kb > 1048576) return `${(kb / 1048576).toFixed(1)} GB`;
+  if (kb > 1024) return `${(kb / 1024).toFixed(0)} MB`;
+  return `${kb} KB`;
+}
+
+function pct(v: number | null | undefined, digits = 1) {
+  if (v === null || v === undefined || Number.isNaN(v)) return '—';
+  return `${(v * 100).toFixed(digits)}%`;
+}
+
+function perMin(v: number | null | undefined, digits = 1) {
+  if (v === null || v === undefined || Number.isNaN(v)) return '—';
+  return v.toFixed(digits);
+}
 
 const jobStatusLabel = (s: number) => {
   if (s === 0) return { label: 'Failed', color: 'text-red-400 bg-red-400/10', dot: 'bg-red-400' };
@@ -85,6 +103,9 @@ export default function InstanceDetailPage() {
   const [loading, setLoading] = useState(true);
   const [jobFilter, setJobFilter] = useState<'all' | 'failed' | 'success'>('all');
   const [hours, setHours] = useState(24);
+  const [resourceGovernor, setResourceGovernor] = useState<ResourceGovernorResponse | null>(null);
+  const [rgLoading, setRgLoading] = useState(false);
+  const [rgLoaded, setRgLoaded] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -111,6 +132,18 @@ export default function InstanceDetailPage() {
       }
     })();
   }, [instanceId, hours]);
+
+  useEffect(() => {
+    if (tab !== 'resource-governor' || rgLoaded) return;
+    setRgLoading(true);
+    api.instanceResourceGovernor(instanceId)
+      .then(setResourceGovernor)
+      .catch(() => setResourceGovernor(null))
+      .finally(() => {
+        setRgLoading(false);
+        setRgLoaded(true);
+      });
+  }, [tab, instanceId, rgLoaded]);
 
   // ── Derived data ───────────────────────────────────────────────────────
 
@@ -184,6 +217,7 @@ export default function InstanceDetailPage() {
     { key: 'jobs', label: 'Jobs', count: failedJobCount > 0 ? failedJobCount : jobs.length },
     { key: 'databases', label: 'Databases', count: databases.length },
     { key: 'drives', label: 'Drives', count: drives.length },
+    { key: 'resource-governor', label: 'Resource Governor' },
   ];
 
   if (loading) return <LoadingSpinner />;
@@ -581,6 +615,186 @@ export default function InstanceDetailPage() {
                 );
               })}
               {drives.length === 0 && <div className="col-span-full"><EmptyState message="No drive data" /></div>}
+            </div>
+          )}
+
+          {/* ── Resource Governor ───────────────────────────────────────── */}
+          {tab === 'resource-governor' && (
+            <div className="space-y-6">
+              {rgLoading && <LoadingSpinner />}
+
+              {!rgLoading && resourceGovernor?.note && (
+                <p className="text-xs text-yellow-400/80 italic">{resourceGovernor.note}</p>
+              )}
+
+              {!rgLoading && resourceGovernor?.config && (
+                <div className="glass rounded-2xl p-6">
+                  <div className="flex items-center justify-between flex-wrap gap-3 mb-4">
+                    <div className="flex items-center gap-3">
+                      <div className={clsx('w-10 h-10 rounded-xl flex items-center justify-center',
+                        resourceGovernor.config.isEnabled ? 'bg-emerald-500/15' : 'bg-gray-500/15')}>
+                        <Gauge className={clsx('w-5 h-5', resourceGovernor.config.isEnabled ? 'text-emerald-400' : 'text-gray-400')} />
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold text-white">
+                          Resource Governor {resourceGovernor.config.isEnabled ? 'Enabled' : 'Disabled'}
+                        </p>
+                        <p className="text-xs text-gray-500">
+                          Since {format(new Date(resourceGovernor.config.validFrom), 'yyyy-MM-dd HH:mm')}
+                        </p>
+                      </div>
+                    </div>
+                    {(resourceGovernor.config.reconfigurationPending || resourceGovernor.config.reconfigurationError) && (
+                      <div className="flex gap-2">
+                        {resourceGovernor.config.reconfigurationPending && (
+                          <span className="text-xs px-2 py-1 rounded-lg bg-yellow-500/10 text-yellow-400 border border-yellow-500/20">Reconfiguration Pending</span>
+                        )}
+                        {resourceGovernor.config.reconfigurationError && (
+                          <span className="text-xs px-2 py-1 rounded-lg bg-red-500/10 text-red-400 border border-red-500/20">Reconfiguration Error</span>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                  <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
+                    <div>
+                      <p className="text-[11px] text-gray-500 uppercase tracking-wider">Classifier Function</p>
+                      <p className="text-white font-mono text-xs mt-0.5">{resourceGovernor.config.classifierFunction || '—'}</p>
+                    </div>
+                    <div>
+                      <p className="text-[11px] text-gray-500 uppercase tracking-wider">Max Outstanding I/O Per Volume</p>
+                      <p className="text-white mt-0.5">{resourceGovernor.config.maxOutstandingIoPerVolume}</p>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {!rgLoading && !resourceGovernor?.config && !resourceGovernor?.note && (
+                <EmptyState message="No Resource Governor configuration collected for this instance." />
+              )}
+
+              {!rgLoading && resourceGovernor && resourceGovernor.configHistory.length > 1 && (
+                <div className="glass rounded-xl overflow-hidden">
+                  <div className="px-4 py-3 bg-slate-800/80 text-xs text-gray-400 uppercase tracking-wider">Configuration History</div>
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="text-left text-xs text-gray-500 border-b border-white/5">
+                        <th className="px-4 py-2">Enabled</th>
+                        <th className="px-4 py-2">Classifier Function</th>
+                        <th className="px-4 py-2">Valid From</th>
+                        <th className="px-4 py-2">Valid To</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-white/5">
+                      {resourceGovernor.configHistory.map((h, i) => (
+                        <tr key={i} className="hover:bg-white/5">
+                          <td className="px-4 py-2">{h.isEnabled ? 'Yes' : 'No'}</td>
+                          <td className="px-4 py-2 font-mono text-xs text-gray-300">{h.classifierFunction || '—'}</td>
+                          <td className="px-4 py-2 text-gray-400 text-xs">{format(new Date(h.validFrom), 'yyyy-MM-dd HH:mm')}</td>
+                          <td className="px-4 py-2 text-gray-400 text-xs">
+                            {h.validTo.startsWith('9999') ? <span className="text-emerald-400">Current</span> : format(new Date(h.validTo), 'yyyy-MM-dd HH:mm')}
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+
+              {!rgLoading && resourceGovernor && (
+                <div>
+                  <div className="flex items-center gap-2 mb-3">
+                    <Cpu className="w-4 h-4 text-blue-400" />
+                    <h3 className="text-sm font-semibold text-white">Resource Pools</h3>
+                    <span className="text-xs text-gray-500">last {hoursLabel(resourceGovernor.periodHours)}</span>
+                  </div>
+                  {resourceGovernor.pools.length === 0 ? (
+                    <EmptyState message="No active custom resource pools. Resource pool/workload group collection only runs once custom workload groups are defined." />
+                  ) : (
+                    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 mb-6">
+                      {resourceGovernor.pools.map((p) => (
+                        <div key={p.poolId} className="glass rounded-2xl p-5">
+                          <div className="flex items-center justify-between mb-3">
+                            <p className="text-sm font-semibold text-white">{p.name}</p>
+                            <span className="text-xs text-gray-500">pool_id {p.poolId}</span>
+                          </div>
+                          <div className="grid grid-cols-2 gap-3 text-xs">
+                            <div>
+                              <p className="text-gray-500 uppercase tracking-wider text-[10px]">CPU (period)</p>
+                              <p className="text-white mt-0.5">{pct(p.periodCpuPercent)}</p>
+                            </div>
+                            <div>
+                              <p className="text-gray-500 uppercase tracking-wider text-[10px]">Cap Utilization</p>
+                              <p className={clsx('mt-0.5', (p.cpuCapUtilizationPercent ?? 0) > 0.9 ? 'text-red-400' : (p.cpuCapUtilizationPercent ?? 0) > 0.7 ? 'text-yellow-400' : 'text-white')}>
+                                {pct(p.cpuCapUtilizationPercent)}
+                              </p>
+                            </div>
+                            <div>
+                              <p className="text-gray-500 uppercase tracking-wider text-[10px]">CPU Min/Max/Cap</p>
+                              <p className="text-white mt-0.5">{p.minCpuPercent}/{p.maxCpuPercent}/{p.capCpuPercent ?? '—'}%</p>
+                            </div>
+                            <div>
+                              <p className="text-gray-500 uppercase tracking-wider text-[10px]">Memory Min/Max</p>
+                              <p className="text-white mt-0.5">{p.minMemoryPercent}/{p.maxMemoryPercent}%</p>
+                            </div>
+                            <div>
+                              <p className="text-gray-500 uppercase tracking-wider text-[10px]">Used / Target Memory</p>
+                              <p className="text-white mt-0.5">{formatKb(p.usedMemoryKb)} / {formatKb(p.targetMemoryKb)}</p>
+                            </div>
+                            <div>
+                              <p className="text-gray-500 uppercase tracking-wider text-[10px]">OOM / Grant Timeouts</p>
+                              <p className={clsx('mt-0.5', p.outOfMemoryCountTotal > 0 || p.memGrantTimeoutCountTotal > 0 ? 'text-red-400' : 'text-white')}>
+                                {p.outOfMemoryCountTotal} / {p.memGrantTimeoutCountTotal}
+                              </p>
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  )}
+
+                  <div className="flex items-center gap-2 mb-3">
+                    <Layers className="w-4 h-4 text-purple-400" />
+                    <h3 className="text-sm font-semibold text-white">Workload Groups</h3>
+                    <span className="text-xs text-gray-500">last {hoursLabel(resourceGovernor.periodHours)}</span>
+                  </div>
+                  {resourceGovernor.workloadGroups.length === 0 ? (
+                    <EmptyState message="No active custom workload groups." />
+                  ) : (
+                    <div className="glass rounded-xl overflow-hidden">
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="bg-slate-800/80 text-left text-xs text-gray-400 uppercase tracking-wider">
+                            <th className="px-4 py-3">Group</th>
+                            <th className="px-4 py-3">Pool</th>
+                            <th className="px-4 py-3">Importance</th>
+                            <th className="px-4 py-3 text-right">Active</th>
+                            <th className="px-4 py-3 text-right">Queued</th>
+                            <th className="px-4 py-3 text-right">Blocked</th>
+                            <th className="px-4 py-3 text-right">CPU</th>
+                            <th className="px-4 py-3 text-right">Req/min</th>
+                            <th className="px-4 py-3 text-right">Lock Waits/min</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-white/5">
+                          {resourceGovernor.workloadGroups.map((g) => (
+                            <tr key={g.groupId} className="hover:bg-white/5">
+                              <td className="px-4 py-2.5 text-white font-medium">{g.name}</td>
+                              <td className="px-4 py-2.5 text-gray-300">{g.poolName}</td>
+                              <td className="px-4 py-2.5 text-gray-300">{g.importance}</td>
+                              <td className="px-4 py-2.5 text-right text-gray-300">{g.activeRequestCount}</td>
+                              <td className="px-4 py-2.5 text-right text-gray-300">{g.queuedRequestCount}</td>
+                              <td className={clsx('px-4 py-2.5 text-right', g.blockedTaskCount > 0 ? 'text-red-400' : 'text-gray-300')}>{g.blockedTaskCount}</td>
+                              <td className="px-4 py-2.5 text-right text-gray-300">{pct(g.periodCpuPercent)}</td>
+                              <td className="px-4 py-2.5 text-right text-gray-300">{perMin(g.periodRequestsPerMin)}</td>
+                              <td className="px-4 py-2.5 text-right text-gray-300">{perMin(g.periodLockWaitsPerMin)}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
           )}
 

--- a/frontend/src/pages/InstanceDetailPage.tsx
+++ b/frontend/src/pages/InstanceDetailPage.tsx
@@ -11,6 +11,7 @@ import type {
   InstanceJobRow,
   InstanceWaitRow,
   ResourceGovernorResponse,
+  InstanceSecurityResponse,
 } from '../api/types';
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, BarChart, Bar, Legend } from 'recharts';
 import StatusBadge from '../components/StatusBadge';
@@ -21,7 +22,8 @@ import EmptyState from '../components/EmptyState';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
   Server, Cpu, HardDrive, Database, Activity, Clock, Shield,
-  ChevronRight, Zap, BarChart3, Timer, AlertTriangle, Gauge, Layers
+  ChevronRight, Zap, BarChart3, Timer, AlertTriangle, Gauge, Layers,
+  Lock, UserX, Skull
 } from 'lucide-react';
 import TimeRangeSelector, { hoursLabel } from '../components/TimeRangeSelector';
 import { clsx } from 'clsx';
@@ -106,6 +108,9 @@ export default function InstanceDetailPage() {
   const [resourceGovernor, setResourceGovernor] = useState<ResourceGovernorResponse | null>(null);
   const [rgLoading, setRgLoading] = useState(false);
   const [rgLoaded, setRgLoaded] = useState(false);
+  const [security, setSecurity] = useState<InstanceSecurityResponse | null>(null);
+  const [securityLoading, setSecurityLoading] = useState(false);
+  const [securityLoaded, setSecurityLoaded] = useState(false);
 
   useEffect(() => {
     (async () => {
@@ -144,6 +149,18 @@ export default function InstanceDetailPage() {
         setRgLoaded(true);
       });
   }, [tab, instanceId, rgLoaded]);
+
+  useEffect(() => {
+    if (tab !== 'security' || securityLoaded) return;
+    setSecurityLoading(true);
+    api.instanceSecurity(instanceId)
+      .then(setSecurity)
+      .catch(() => setSecurity(null))
+      .finally(() => {
+        setSecurityLoading(false);
+        setSecurityLoaded(true);
+      });
+  }, [tab, instanceId, securityLoaded]);
 
   // ── Derived data ───────────────────────────────────────────────────────
 
@@ -218,6 +235,7 @@ export default function InstanceDetailPage() {
     { key: 'databases', label: 'Databases', count: databases.length },
     { key: 'drives', label: 'Drives', count: drives.length },
     { key: 'resource-governor', label: 'Resource Governor' },
+    { key: 'security', label: 'Security' },
   ];
 
   if (loading) return <LoadingSpinner />;
@@ -794,6 +812,133 @@ export default function InstanceDetailPage() {
                     </div>
                   )}
                 </div>
+              )}
+            </div>
+          )}
+
+          {/* ── Security ─────────────────────────────────────────────────── */}
+          {tab === 'security' && (
+            <div className="space-y-6">
+              {securityLoading && <LoadingSpinner />}
+
+              {!securityLoading && security?.note && (
+                <p className="text-xs text-yellow-400/80 italic">{security.note}</p>
+              )}
+
+              {!securityLoading && security && (
+                <>
+                  <div>
+                    <div className="flex items-center gap-2 mb-3">
+                      <Lock className="w-4 h-4 text-red-400" />
+                      <h3 className="text-sm font-semibold text-white">Sysadmin Role Members</h3>
+                    </div>
+                    {security.sysadminMembers.length === 0 ? (
+                      <EmptyState message="No sysadmin role members collected." />
+                    ) : (
+                      <div className="glass rounded-xl overflow-hidden">
+                        <table className="w-full text-sm">
+                          <thead>
+                            <tr className="bg-slate-800/80 text-left text-xs text-gray-400 uppercase tracking-wider">
+                              <th className="px-4 py-3">Login / Group</th>
+                              <th className="px-4 py-3">Type</th>
+                              <th className="px-4 py-3">Status</th>
+                              <th className="px-4 py-3">Created</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-white/5">
+                            {security.sysadminMembers.map((m, i) => (
+                              <tr key={i} className="hover:bg-white/5">
+                                <td className="px-4 py-2.5 text-white font-medium">{m.memberName}</td>
+                                <td className="px-4 py-2.5 text-gray-300 text-xs">{m.memberType}</td>
+                                <td className="px-4 py-2.5">
+                                  {m.isDisabled ? (
+                                    <span className="text-xs text-gray-500">Disabled</span>
+                                  ) : (
+                                    <span className="text-xs text-emerald-400">Active</span>
+                                  )}
+                                </td>
+                                <td className="px-4 py-2.5 text-gray-400 text-xs">{m.createDate ? format(new Date(m.createDate), 'yyyy-MM-dd') : '—'}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+                  </div>
+
+                  <div>
+                    <div className="flex items-center gap-2 mb-3">
+                      <UserX className="w-4 h-4 text-yellow-400" />
+                      <h3 className="text-sm font-semibold text-white">Failed Logins</h3>
+                      {security.failedLogins.count > 0 && (
+                        <span className="text-xs text-gray-500">
+                          {security.failedLogins.count} total
+                          {security.failedLogins.lastLogDate && ` · last ${formatDistanceToNow(new Date(security.failedLogins.lastLogDate), { addSuffix: true })}`}
+                        </span>
+                      )}
+                    </div>
+                    {security.failedLogins.recent.length === 0 ? (
+                      <EmptyState message="No failed logins recorded." />
+                    ) : (
+                      <div className="glass rounded-xl overflow-hidden max-h-96 overflow-y-auto">
+                        <table className="w-full text-sm">
+                          <thead className="sticky top-0">
+                            <tr className="bg-slate-800/80 text-left text-xs text-gray-400 uppercase tracking-wider">
+                              <th className="px-4 py-3">Time</th>
+                              <th className="px-4 py-3">Detail</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-white/5">
+                            {security.failedLogins.recent.map((f, i) => (
+                              <tr key={i} className="hover:bg-white/5">
+                                <td className="px-4 py-2.5 text-gray-400 text-xs whitespace-nowrap align-top">{format(new Date(f.logDate), 'yyyy-MM-dd HH:mm:ss')}</td>
+                                <td className="px-4 py-2.5 text-gray-300 text-xs font-mono break-all">{f.text || '—'}</td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+                  </div>
+
+                  <div>
+                    <div className="flex items-center gap-2 mb-3">
+                      <Skull className="w-4 h-4 text-purple-400" />
+                      <h3 className="text-sm font-semibold text-white">Killed Session Audit Log</h3>
+                    </div>
+                    {security.killedSessions.length === 0 ? (
+                      <EmptyState message="No session-kill actions recorded for this instance." />
+                    ) : (
+                      <div className="glass rounded-xl overflow-hidden">
+                        <table className="w-full text-sm">
+                          <thead>
+                            <tr className="bg-slate-800/80 text-left text-xs text-gray-400 uppercase tracking-wider">
+                              <th className="px-4 py-3">Session</th>
+                              <th className="px-4 py-3">Killed By</th>
+                              <th className="px-4 py-3">When</th>
+                              <th className="px-4 py-3">Status</th>
+                            </tr>
+                          </thead>
+                          <tbody className="divide-y divide-white/5">
+                            {security.killedSessions.map((k, i) => (
+                              <tr key={i} className="hover:bg-white/5">
+                                <td className="px-4 py-2.5 text-white font-mono text-xs">{k.sessionId}</td>
+                                <td className="px-4 py-2.5 text-gray-300">{k.killedBy}</td>
+                                <td className="px-4 py-2.5 text-gray-400 text-xs">{format(new Date(k.logDate), 'yyyy-MM-dd HH:mm:ss')}</td>
+                                <td className="px-4 py-2.5">
+                                  <span className={clsx('text-xs',
+                                    k.status === 'KILLED' ? 'text-emerald-400' : k.status === 'REQUEST' ? 'text-yellow-400' : 'text-red-400')}>
+                                    {k.status || '—'}
+                                  </span>
+                                </td>
+                              </tr>
+                            ))}
+                          </tbody>
+                        </table>
+                      </div>
+                    )}
+                  </div>
+                </>
               )}
             </div>
           )}

--- a/frontend/src/pages/InstanceDetailPage.tsx
+++ b/frontend/src/pages/InstanceDetailPage.tsx
@@ -12,6 +12,7 @@ import type {
   InstanceWaitRow,
   ResourceGovernorResponse,
   InstanceSecurityResponse,
+  InstanceTableSizeRow,
 } from '../api/types';
 import { AreaChart, Area, XAxis, YAxis, Tooltip, ResponsiveContainer, BarChart, Bar, Legend } from 'recharts';
 import StatusBadge from '../components/StatusBadge';
@@ -23,7 +24,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import {
   Server, Cpu, HardDrive, Database, Activity, Clock, Shield,
   ChevronRight, Zap, BarChart3, Timer, AlertTriangle, Gauge, Layers,
-  Lock, UserX, Skull
+  Lock, UserX, Skull, Table2
 } from 'lucide-react';
 import TimeRangeSelector, { hoursLabel } from '../components/TimeRangeSelector';
 import { clsx } from 'clsx';
@@ -111,6 +112,10 @@ export default function InstanceDetailPage() {
   const [security, setSecurity] = useState<InstanceSecurityResponse | null>(null);
   const [securityLoading, setSecurityLoading] = useState(false);
   const [securityLoaded, setSecurityLoaded] = useState(false);
+  const [tableSizes, setTableSizes] = useState<InstanceTableSizeRow[]>([]);
+  const [tableSizesLoading, setTableSizesLoading] = useState(false);
+  const [tableSizesLoaded, setTableSizesLoaded] = useState(false);
+  const [tableSizesGrowthDays, setTableSizesGrowthDays] = useState(30);
 
   useEffect(() => {
     (async () => {
@@ -161,6 +166,21 @@ export default function InstanceDetailPage() {
         setSecurityLoaded(true);
       });
   }, [tab, instanceId, securityLoaded]);
+
+  useEffect(() => {
+    if (tab !== 'table-sizes' || tableSizesLoaded) return;
+    setTableSizesLoading(true);
+    api.instanceTableSizes(instanceId)
+      .then(res => {
+        setTableSizes(Array.isArray(res.data) ? res.data : []);
+        setTableSizesGrowthDays(res.growthDays);
+      })
+      .catch(() => setTableSizes([]))
+      .finally(() => {
+        setTableSizesLoading(false);
+        setTableSizesLoaded(true);
+      });
+  }, [tab, instanceId, tableSizesLoaded]);
 
   // ── Derived data ───────────────────────────────────────────────────────
 
@@ -236,6 +256,7 @@ export default function InstanceDetailPage() {
     { key: 'drives', label: 'Drives', count: drives.length },
     { key: 'resource-governor', label: 'Resource Governor' },
     { key: 'security', label: 'Security' },
+    { key: 'table-sizes', label: 'Table Sizes' },
   ];
 
   if (loading) return <LoadingSpinner />;
@@ -938,6 +959,60 @@ export default function InstanceDetailPage() {
                       </div>
                     )}
                   </div>
+                </>
+              )}
+            </div>
+          )}
+
+          {/* ── Table Sizes ──────────────────────────────────────────────── */}
+          {tab === 'table-sizes' && (
+            <div className="space-y-4">
+              {tableSizesLoading && <LoadingSpinner />}
+              {!tableSizesLoading && (
+                <>
+                  <div className="flex items-center gap-2">
+                    <Table2 className="w-4 h-4 text-blue-400" />
+                    <h3 className="text-sm font-semibold text-white">Largest Tables</h3>
+                    <span className="text-xs text-gray-500">
+                      by reserved space, growth over last {tableSizesGrowthDays} days
+                    </span>
+                  </div>
+                  {tableSizes.length === 0 ? (
+                    <EmptyState message="No table size history collected for this instance yet." />
+                  ) : (
+                    <div className="glass rounded-xl overflow-hidden">
+                      <table className="w-full text-sm">
+                        <thead>
+                          <tr className="bg-slate-800/80 text-left text-xs text-gray-400 uppercase tracking-wider">
+                            <th className="px-4 py-3">Database</th>
+                            <th className="px-4 py-3">Table</th>
+                            <th className="px-4 py-3 text-right">Rows</th>
+                            <th className="px-4 py-3 text-right">Reserved</th>
+                            <th className="px-4 py-3 text-right">Growth / day</th>
+                          </tr>
+                        </thead>
+                        <tbody className="divide-y divide-white/5">
+                          {tableSizes.map((t) => (
+                            <tr key={t.ObjectID} className="hover:bg-white/5">
+                              <td className="px-4 py-2.5 text-gray-300">{t.DatabaseName}</td>
+                              <td className="px-4 py-2.5 text-white font-medium font-mono text-xs">{t.SchemaName}.{t.ObjectName}</td>
+                              <td className="px-4 py-2.5 text-right text-gray-300">{t.Rows?.toLocaleString()}</td>
+                              <td className="px-4 py-2.5 text-right text-gray-300">{formatKb(t.ReservedKb)}</td>
+                              <td className="px-4 py-2.5 text-right">
+                                {t.CalcDays && t.CalcDays >= 1 ? (
+                                  <span className={clsx((t.AvgKbPerDay ?? 0) > 0 ? 'text-yellow-400' : 'text-gray-400')}>
+                                    {(t.AvgKbPerDay ?? 0) >= 0 ? '+' : ''}{formatKb(t.AvgKbPerDay)}/day
+                                  </span>
+                                ) : (
+                                  <span className="text-gray-600 text-xs">not enough history</span>
+                                )}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  )}
                 </>
               )}
             </div>

--- a/frontend/src/pages/QueryStorePage.tsx
+++ b/frontend/src/pages/QueryStorePage.tsx
@@ -1,11 +1,23 @@
 import { useState, useEffect } from 'react';
 import { api } from '../api/api';
-import type { InstanceListRow, QueryStoreRow } from '../api/types';
+import type { InstanceListRow, PlanForcingLogRow, QueryStoreRow } from '../api/types';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Cell } from 'recharts';
 import { Search as SearchIcon } from 'lucide-react';
+import { format } from 'date-fns';
+import TabNav from '../components/TabNav';
+
+function statusColor(status: string | null | undefined): string {
+  const s = (status || '').toUpperCase();
+  if (s === 'SUCCESS' || s === 'APPLIED') return 'bg-emerald-400/10 text-emerald-400';
+  if (s === 'FAILED' || s === 'ERROR') return 'bg-red-400/10 text-red-400';
+  if (s === 'REQUEST' || s === 'PENDING') return 'bg-yellow-400/10 text-yellow-400';
+  return 'bg-gray-400/10 text-gray-400';
+}
 
 export default function QueryStorePage() {
+  const [tab, setTab] = useState<'top-queries' | 'plan-forcing'>('top-queries');
   const [data, setData] = useState<QueryStoreRow[]>([]);
+  const [planForcingLog, setPlanForcingLog] = useState<PlanForcingLogRow[]>([]);
   const [instances, setInstances] = useState<InstanceListRow[]>([]);
   const [instanceId, setInstanceId] = useState<number | undefined>();
   const [loading, setLoading] = useState(false);
@@ -13,11 +25,16 @@ export default function QueryStorePage() {
   const [sortBy, setSortBy] = useState<'avgCpuTime' | 'avgDuration' | 'countExecutions'>('avgCpuTime');
 
   useEffect(() => { api.instances().then(setInstances).catch(() => {}); }, []);
+
   useEffect(() => {
     if (!instanceId) return;
     setLoading(true);
-    api.performanceQueryStore(instanceId).then(r => { setData(r.data || []); setNote(r.note || ''); }).finally(() => setLoading(false));
-  }, [instanceId]);
+    if (tab === 'top-queries') {
+      api.performanceQueryStore(instanceId).then(r => { setData(r.data || []); setNote(r.note || ''); }).finally(() => setLoading(false));
+    } else {
+      api.performancePlanForcingLog(instanceId).then(r => { setPlanForcingLog(r.data || []); setNote(r.note || ''); }).finally(() => setLoading(false));
+    }
+  }, [instanceId, tab]);
 
   const sorted = [...data].sort((a, b) => (b[sortBy] || 0) - (a[sortBy] || 0));
   const top10 = sorted.slice(0, 10);
@@ -31,15 +48,28 @@ export default function QueryStorePage() {
           <option value="">Select Instance...</option>
           {instances.map((inst) => <option key={inst.InstanceID} value={inst.InstanceID}>{inst.InstanceDisplayName || inst.Instance || inst.InstanceID}</option>)}
         </select>
-        <select value={sortBy} onChange={e => setSortBy(e.target.value as typeof sortBy)} className={inputCls}>
-          <option value="avgCpuTime">Sort by CPU</option>
-          <option value="avgDuration">Sort by Duration</option>
-          <option value="countExecutions">Sort by Exec Count</option>
-        </select>
+        {tab === 'top-queries' && (
+          <select value={sortBy} onChange={e => setSortBy(e.target.value as typeof sortBy)} className={inputCls}>
+            <option value="avgCpuTime">Sort by CPU</option>
+            <option value="avgDuration">Sort by Duration</option>
+            <option value="countExecutions">Sort by Exec Count</option>
+          </select>
+        )}
       </div>
+
+      <TabNav
+        tabs={[
+          { key: 'top-queries', label: 'Top Queries' },
+          { key: 'plan-forcing', label: 'Plan Forcing History' },
+        ]}
+        active={tab}
+        onChange={key => setTab(key as typeof tab)}
+      />
+
       {note && <p className="text-xs text-amber-400/70">{note}</p>}
-      {!instanceId ? <p className="text-gray-500 text-sm">Select an instance to view Query Store data.</p> :
-        loading ? <div className="text-gray-400">Loading...</div> : (
+      {!instanceId ? <p className="text-gray-500 text-sm">Select an instance to view {tab === 'top-queries' ? 'Query Store' : 'plan forcing'} data.</p> :
+        loading ? <div className="text-gray-400">Loading...</div> :
+        tab === 'top-queries' ? (
         <>
           {top10.length > 0 && (
             <div className="glass rounded-xl p-6 gradient-border">
@@ -69,7 +99,35 @@ export default function QueryStorePage() {
             </table>
           </div>
         </>
-      )}
+        ) : (
+        <div className="glass rounded-xl p-6 gradient-border overflow-x-auto">
+          <p className="text-xs text-gray-500 mb-4">
+            Real audit trail from DBA Dash's own forced-plan actions (dbo.PlanForcingLog) — who forced or
+            unforced a plan, when, and its status. Forcing a plan itself is still done from the DBA Dash
+            desktop client; this is a read-only history.
+          </p>
+          <table className="w-full text-sm">
+            <thead><tr className="border-b border-white/10 text-left text-gray-300 font-semibold">
+              <th className="pb-2">Date</th><th className="pb-2">Type</th><th className="pb-2">Status</th><th className="pb-2">Database</th>
+              <th className="pb-2">Object</th><th className="pb-2">Query/Plan ID</th><th className="pb-2">User</th><th className="pb-2">Notes</th>
+            </tr></thead>
+            <tbody>{planForcingLog.map(r => (
+              <tr key={r.MessageGroupID} className="border-b border-white/5 hover:bg-slate-800/50">
+                <td className="py-2 text-gray-300 text-xs whitespace-nowrap">{r.log_date ? format(new Date(r.log_date), 'MMM d HH:mm:ss') : '—'}</td>
+                <td className="py-2 text-gray-300 text-xs">{r.log_type}</td>
+                <td className="py-2"><span className={`text-xs px-2 py-0.5 rounded ${statusColor(r.status)}`}>{r.status || '—'}</span></td>
+                <td className="py-2 text-gray-300 text-xs">{r.database_name}</td>
+                <td className="py-2 text-white text-xs max-w-xs truncate" title={r.query_sql_text || undefined}>{r.object_name || r.query_sql_text?.substring(0, 60) || '—'}</td>
+                <td className="py-2 text-gray-400 text-xs font-mono">{r.query_id} / {r.plan_id}</td>
+                <td className="py-2 text-gray-300 text-xs">{r.user_name}</td>
+                <td className="py-2 text-gray-400 text-xs max-w-xs truncate" title={r.notes || undefined}>{r.notes || '—'}</td>
+              </tr>
+            ))}</tbody>
+          </table>
+          {planForcingLog.length === 0 && <p className="text-gray-500 text-sm py-4 text-center">No plan forcing actions recorded for this instance.</p>}
+        </div>
+        )
+      }
     </div>
   );
 }


### PR DESCRIPTION
## Description

Closes #109. DBA Dash collects a lot of data this webview never surfaced - either the table existed but no endpoint read it, or an endpoint read it but processed it wrong (a fabricated baseline, `NULL`-stubbed query text). This PR closes that gap across six areas, each verified against the real live DBADashDB rather than just confirmed to build:

- **Real CPU baseline** - replaced a fabricated `Math.sin()` "Baseline (last week)" toggle on Performance Analysis with an actual 14-day time-of-day average computed from `dbo.CPU` history.
- **Real query text** - `dbo.RunningQueries.query_text` was hard-coded `NULL`; now joined through `dbo.QueryText` via `sql_handle` on Running Queries and Blocking.
- **Plan Forcing History** - new read-only tab on Query Store surfacing `dbo.PlanForcingLog`, DBA Dash's real forced-plan audit trail (previously unused).
- **Corruption detail view** - new page/endpoint replacing the status-only dot with real findings from `dbo.Corruption` (source, row count, ack status), with acknowledge support for Operator/Admin.
- **Resource Governor** - new instance-detail tab: current config + full change history (`dbo.ResourceGovernorConfiguration(History)`), and active pool/workload-group utilization computed with the same formulas as DBA Dash's own `ResourceGovernorResourcePools_Get`/`ResourceGovernorWorkloadGroups_Get` procs.
- **Security/audit** - new instance-detail tab: sysadmin fixed-role membership (`dbo.ServerPrincipals`/`ServerRoleMembers`), failed logins (`dbo.FailedLogins`), and the killed-session audit trail (`dbo.KillSessionLog`), all read-only.
- **Table growth, trace flags, mirroring, log shipping** - largest/fastest-growing tables per instance (replicating `TableSize_Get`'s exact growth formulas), a Trace Flags tab alongside the existing sp_configure Configuration view, and Database Mirroring / Log Shipping status folded into the HA/DR page, which previously dead-ended on "No Availability Groups configured" for any instance using either of those instead of Always On.

**Deliberately out of scope**, each for a concrete reason rather than an oversight:
- DDL author/timestamp on Schema Changes - `dbo.DDL` only has a hash + compressed blob, no login/event-type/timestamp column exists to show.
- `SessionWaits` - only meaningful as a drill-down on one specific captured `RunningQueries` snapshot, not a standalone report.
- Raw `Server/DatabasePermissions` + `DatabasePrincipals`/`DatabaseRoleMembers` browsing - no existing DBA Dash report to validate query logic against, and GRANT/DENY/REVOKE resolution is too easy to get subtly wrong to guess at.
- A live "kill session" action - `KillSessionLog` is tied to a real feature that messages the collector agent over Service Broker to kill a live SPID; that's a genuine operational action, not something to bolt on unrequested.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: ___

## Checklist

- [x] `npm run build` passes (frontend)
- [x] `dotnet build` passes (backend)
- [x] Tested in browser (dark theme) 
- [x] No new TypeScript errors
- [x] SQL queries use parameterized `@param` (no string concat of request values)


## Screenshots

Not included - see live verification notes above in place of visual screenshots.