### PR TITLE
Fix group-only scope SQL, inverted Monitored Servers status badge, and vitest .tsx glob (#111)

### DIFF
--- a/backend.tests/UserScopeTests.cs
+++ b/backend.tests/UserScopeTests.cs
@@ -1,11 +1,25 @@
 using System.Security.Claims;
 using DBADashWebView.Auth;
+using DBADashWebView.Data;
+using DBADashWebView.Endpoints;
+using Microsoft.Extensions.Configuration;
 using Xunit;
 
 namespace DBADashWebView.Tests;
 
 public sealed class UserScopeTests
 {
+    /// <summary>
+    /// A data service with no connection string configured. Any code path that
+    /// actually reaches SQL throws, so these tests prove the scope helpers
+    /// short-circuit before issuing a query.
+    /// </summary>
+    private static SqlDataService UnusableSqlService() =>
+        new(new ConfigurationBuilder().Build());
+
+    private static ClaimsPrincipal PrincipalWith(params Claim[] claims) =>
+        new(new ClaimsIdentity(claims, "test"));
+
     [Fact]
     public void FromPrincipal_NullPrincipal_ReturnsUnrestricted()
     {
@@ -96,5 +110,87 @@ public sealed class UserScopeTests
         Assert.Equal("a", tuples[0].value);
         Assert.Equal("@scope_tag_1", tuples[1].name);
         Assert.Equal("b", tuples[1].value);
+    }
+
+    // ---------------------------------------------------------------------
+    // Group-only scope: a user with allowed group ids but no allowed tags.
+    // There is no SQL translation for group scope yet, so such a scope must
+    // behave as unrestricted instead of emitting a tag predicate with an
+    // empty IN () list or a dangling AND.
+    // ---------------------------------------------------------------------
+
+    private static ClaimsPrincipal GroupOnlyPrincipal() => PrincipalWith(
+        new Claim(ClaimTypes.Name, "alice"),
+        new Claim(AppClaimTypes.AllowedGroupId, "1"),
+        new Claim(AppClaimTypes.AllowedGroupId, "5"));
+
+    [Fact]
+    public void HasTagScope_GroupOnlyScope_IsFalse()
+    {
+        var scope = UserScope.FromPrincipal(GroupOnlyPrincipal());
+
+        Assert.False(scope.IsUnrestricted);
+        Assert.False(scope.HasTagScope);
+        Assert.Equal(new[] { 1, 5 }, scope.AllowedGroupIds);
+    }
+
+    [Fact]
+    public void BuildInstanceFilter_GroupOnlyScope_ReturnsEmptyPredicate()
+    {
+        var scope = UserScope.FromPrincipal(GroupOnlyPrincipal());
+
+        // Must never produce "IN ()", which is a T-SQL syntax error.
+        Assert.Equal(string.Empty, scope.BuildInstanceFilter("i.InstanceID"));
+    }
+
+    [Fact]
+    public void ScopedInstanceFilter_GroupOnlyScope_EmitsNoSqlFragment()
+    {
+        var (snippet, parameters) = GroupOnlyPrincipal().ScopedInstanceFilter("i.InstanceID");
+
+        // A bare " AND " here would break every query that inlines the snippet.
+        Assert.Equal(string.Empty, snippet);
+        Assert.Empty(parameters);
+    }
+
+    [Fact]
+    public void ScopedInstanceFilter_TagScope_EmitsPredicateAndParameters()
+    {
+        var principal = PrincipalWith(new Claim(AppClaimTypes.AllowedTag, "prod"));
+
+        var (snippet, parameters) = principal.ScopedInstanceFilter("i.InstanceID");
+
+        Assert.StartsWith(" AND ", snippet);
+        Assert.Contains("i.InstanceID IN", snippet);
+        Assert.Single(parameters);
+        Assert.Equal("@scope_tag_0", parameters[0].name);
+        Assert.Equal("prod", parameters[0].value);
+    }
+
+    [Fact]
+    public async Task AllowedInstanceIdsAsync_GroupOnlyScope_ReturnsNullWithoutQueryingSql()
+    {
+        var scope = UserScope.FromPrincipal(GroupOnlyPrincipal());
+
+        var allowed = await scope.AllowedInstanceIdsAsync(UnusableSqlService(), CancellationToken.None);
+
+        Assert.Null(allowed);
+    }
+
+    [Fact]
+    public async Task IsInstanceAllowedAsync_GroupOnlyScope_AllowsWithoutQueryingSql()
+    {
+        var scope = UserScope.FromPrincipal(GroupOnlyPrincipal());
+
+        Assert.True(await scope.IsInstanceAllowedAsync(UnusableSqlService(), 42, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task EnsureInstanceAccessAsync_GroupOnlyScope_DoesNotDenyAccess()
+    {
+        var deny = await GroupOnlyPrincipal()
+            .EnsureInstanceAccessAsync(42, UnusableSqlService(), CancellationToken.None);
+
+        Assert.Null(deny);
     }
 }

--- a/backend/Auth/UserScope.cs
+++ b/backend/Auth/UserScope.cs
@@ -57,6 +57,15 @@ public sealed class UserScope
     public bool IsUnrestricted => AllowedTags.Count == 0 && AllowedGroupIds.Count == 0;
 
     /// <summary>
+    /// True when the scope can actually be enforced in SQL. Only tag scope is
+    /// translated into a predicate today, so a scope that carries group ids but
+    /// no tags has nothing to filter on. Callers must check this rather than
+    /// <see cref="IsUnrestricted"/> before building a tag predicate — otherwise
+    /// they emit <c>IN ()</c> / a dangling <c>AND</c> and the query fails.
+    /// </summary>
+    public bool HasTagScope => AllowedTags.Count > 0;
+
+    /// <summary>
     /// Returns a SQL predicate (without leading AND) that constrains the
     /// supplied <paramref name="instanceIdColumn"/> to instances the caller is
     /// allowed to see. Returns an empty string when no scope is set. The
@@ -126,7 +135,9 @@ public sealed class UserScope
 
     /// <summary>
     /// Returns the set of instance ids the caller is allowed to see, or <c>null</c>
-    /// when the scope is unrestricted (callers should treat null as "no filter").
+    /// when there is no tag scope to enforce (callers should treat null as "no
+    /// filter"). A scope carrying only group ids yields <c>null</c>, matching the
+    /// documented "group scope by itself behaves as unrestricted" behaviour.
     /// Used by aggregate endpoints (dashboard / reports) that post-filter row
     /// collections instead of rewriting every SQL aggregate.
     /// </summary>
@@ -134,7 +145,7 @@ public sealed class UserScope
         DBADashWebView.Data.SqlDataService sql,
         CancellationToken cancellationToken)
     {
-        if (IsUnrestricted)
+        if (!HasTagScope)
         {
             return null;
         }
@@ -157,14 +168,14 @@ public sealed class UserScope
     /// <summary>
     /// Checks whether the given instance id falls within the user's scope by
     /// running a single, parameterised <c>SELECT 1</c> against the tag tables.
-    /// Returns true immediately when the scope is unrestricted.
+    /// Returns true immediately when there is no tag scope to enforce.
     /// </summary>
     public async Task<bool> IsInstanceAllowedAsync(
         DBADashWebView.Data.SqlDataService sql,
         int instanceId,
         CancellationToken cancellationToken)
     {
-        if (IsUnrestricted)
+        if (!HasTagScope)
         {
             return true;
         }

--- a/backend/Endpoints/ScopeEndpointExtensions.cs
+++ b/backend/Endpoints/ScopeEndpointExtensions.cs
@@ -45,12 +45,15 @@ internal static class ScopeEndpointExtensions
         string parameterPrefix = "@scope")
     {
         var scope = UserScope.FromPrincipal(user);
-        if (scope.IsUnrestricted)
+        var predicate = scope.BuildInstanceFilter(instanceIdColumn, parameterPrefix);
+        if (string.IsNullOrEmpty(predicate))
         {
+            // No tag scope to enforce (unrestricted, or group-only scope, which
+            // is not translated into SQL yet). Emitting " AND " on its own here
+            // would produce invalid T-SQL at every call site.
             return (string.Empty, Array.Empty<(string, object?)>());
         }
 
-        var predicate = scope.BuildInstanceFilter(instanceIdColumn, parameterPrefix);
         var parameters = scope.ParameterTuples(parameterPrefix).ToArray();
         return (" AND " + predicate, parameters);
     }

--- a/frontend/src/components/StatusBadge.test.tsx
+++ b/frontend/src/components/StatusBadge.test.tsx
@@ -1,0 +1,61 @@
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import StatusBadge from './StatusBadge';
+
+/**
+ * First component test in the suite. Besides covering StatusBadge it acts as a
+ * guard for the vitest `include` glob: if `.tsx` tests ever stop being picked
+ * up again, this file disappears from the run.
+ */
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function renderBadge(props: Parameters<typeof StatusBadge>[0]) {
+  act(() => {
+    root.render(<StatusBadge {...props} />);
+  });
+  return container.textContent ?? '';
+}
+
+describe('StatusBadge', () => {
+  // The DBADashStatusEnum mapping is documented in the README and relied on by
+  // every dashboard. Swapping two of these silently mislabels fleet health.
+  it.each([
+    [1, 'Critical'],
+    [2, 'Warning'],
+    [3, 'N/A'],
+    [4, 'OK'],
+    [5, 'Acknowledged'],
+  ])('renders status %i as "%s"', (status, expected) => {
+    expect(renderBadge({ status })).toBe(expected);
+  });
+
+  it('falls back to N/A for an unknown status', () => {
+    expect(renderBadge({ status: 99 })).toBe('N/A');
+  });
+
+  it('prefers an explicit label over the enum label', () => {
+    expect(renderBadge({ status: 1, label: 'Offline' })).toBe('Offline');
+  });
+
+  it('applies the critical colour only to status 1', () => {
+    renderBadge({ status: 1 });
+    expect(container.querySelector('span')?.className).toContain('text-red-400');
+
+    renderBadge({ status: 4 });
+    expect(container.querySelector('span')?.className).toContain('text-emerald-400');
+  });
+});

--- a/frontend/src/pages/ConfigServersPage.tsx
+++ b/frontend/src/pages/ConfigServersPage.tsx
@@ -50,7 +50,10 @@ export default function ConfigServersPage() {
                 <td className="py-3 text-gray-400 text-xs">{inst.Edition || '—'}</td>
                 <td className="py-3 text-gray-400 text-xs">{inst.ProductVersion || '—'}</td>
                 <td className="py-3 text-center">
-                  <StatusBadge status={inst.IsActive ? 1 : 4} />
+                  {/* DBA Dash enum: 4 = OK, 3 = N/A. An active instance is
+                      healthy, not Critical (1), and an intentionally disabled
+                      one is N/A rather than OK. */}
+                  <StatusBadge status={inst.IsActive ? 4 : 3} />
                 </td>
                 <td className="py-3 text-center">
                   <div className="flex items-center justify-center gap-1">

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,12 @@
+// Shared vitest setup for component tests.
+//
+// React only treats `act(...)` as supported when this flag is set, otherwise
+// every component test logs "The current testing environment is not configured
+// to support act(...)" and state updates are not flushed deterministically.
+declare global {
+  var IS_REACT_ACT_ENVIRONMENT: boolean;
+}
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+export {};

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -6,6 +6,9 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    include: ['src/**/*.test.ts'],
+    setupFiles: ['./src/test-setup.ts'],
+    // Must cover .tsx as well — component tests live next to the components
+    // they cover, and a bare '*.test.ts' glob silently skips every one of them.
+    include: ['src/**/*.test.{ts,tsx}'],
   },
 });


### PR DESCRIPTION
## Description

Fixes the three defects from #111 that have a concrete repro. The remaining findings in that issue (exception text leaking through HTTP 200, the mockup config pages, CI not running the linter, non-atomic user-store writes) are left for separate PRs so this one stays reviewable.

### 1. Group-only user scope generated invalid T-SQL

`UserScope` guarded its SQL paths on `IsUnrestricted` — `no tags AND no groups` — but only *tag* scope is translated into SQL. A user with group ids and no tags was therefore "restricted" with nothing to build a predicate from:

- `AllowedInstanceIdsAsync` / `IsInstanceAllowedAsync` → `WHERE t.TagName IN ()`
- `ScopedInstanceFilter` → a bare `" AND "`, inlined into ~20 queries as `WHERE 1=1 AND `

Both are T-SQL syntax errors. Per-instance endpoints returned 500; aggregate endpoints swallowed the `SqlException` and returned 200 with an empty payload, so the UI just showed empty tables.

Added `HasTagScope` and guard on that instead. This restores the behaviour already documented in `BuildInstanceFilter` — *"group scope by itself behaves as unrestricted"* — until group scope gets a SQL translation.

`ScopedInstanceFilter` now derives the predicate first and returns an empty snippet when there's nothing to filter on, so it can't emit a dangling `AND` regardless of how the scope is shaped.

### 2. Monitored Servers showed every active instance as red "Critical"

`ConfigServersPage` mapped `IsActive` onto `DBADashStatusEnum` backwards:

```diff
-<StatusBadge status={inst.IsActive ? 1 : 4} />   // 1 = Critical, 4 = OK
+<StatusBadge status={inst.IsActive ? 4 : 3} />   // 4 = OK, 3 = N/A
```

Since `/api/instances` filters on `WHERE i.IsActive = 1`, every row on the page is active — so the Status column was red for the entire fleet. Disabled instances map to N/A rather than OK, since an intentionally disabled instance isn't healthy, it's not being checked.

### 3. vitest never ran `.tsx` tests

`include: ['src/**/*.test.ts']` doesn't match `.test.tsx`, so component tests were silently skipped and CI stayed green. Confirmed by dropping a `.test.tsx` with `expect(1).toBe(2)` into `src/` — the run still reported `2 passed / 4 passed` and exited 0. That's why there were zero component tests for 64 `.tsx` files.

Widened the glob and added `src/test-setup.ts` setting `IS_REACT_ACT_ENVIRONMENT`, so component tests can use `act()` without React warnings.

### Tests

- **7 new backend tests** for the group-only scope case. The 4 behavioural ones fail against the unfixed code — the three that reach SQL fail with `InvalidOperationException: ConnectionString has not been initialized`, which is exactly the path that executes `IN ()` in production, and `ScopedInstanceFilter` fails on the dangling `" AND "`.
- **1 new component test** pinning the `DBADashStatusEnum` label and colour mapping (a swap here silently mislabels fleet health on every dashboard). It doubles as a guard for the include glob — if `.tsx` tests stop being collected again, this file disappears from the run.

Backend 25 → 32 tests, frontend 4 → 12.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: ___

## Checklist

- [x] `npm run build` passes (frontend)
- [x] `dotnet build` passes (backend) — 0 warnings, 0 errors
- [x] Tested in browser (dark theme)
- [x] No new TypeScript errors
- [x] SQL queries use parameterized `@param` (no string concat)

Also run locally: `dotnet test` 32/32, `npm run test:run` 12/12, `npx playwright test` 2/2. `npm run lint` is clean on every file touched here (`main`'s 88 pre-existing errors are untouched — see #111).

## Screenshots

Verified in a real browser (Playwright, dark theme) on **Settings → Monitored Servers** with a stubbed `/api/instances` returning one active and one inactive instance:

| Instance | Before | After |
|---|---|---|
| `sql-prod-01` (`IsActive: true`) | 🔴 **Critical** | 🟢 **OK** |
| `sql-old-02` (`IsActive: false`) | 🟢 **OK** | ⚪ **N/A** |

In production every row on this page is active (`/api/instances` filters on `IsActive = 1`), so the "before" column was red for the whole fleet.

Closes #111
