### PR TITLE
Remove failing build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 
 *Browser-based companion to [DBA Dash](https://github.com/trimble-oss/dba-dash) — monitor hundreds of SQL Servers from any device.*
 
-[![Build](https://github.com/BenediktSchackenberg/dbadashwebview/actions/workflows/build.yml/badge.svg)](https://github.com/BenediktSchackenberg/dbadashwebview/actions/workflows/build.yml)
 [![MIT License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![.NET 10](https://img.shields.io/badge/.NET-10.0-purple.svg)](https://dotnet.microsoft.com/)
 [![React](https://img.shields.io/badge/React-19-61dafb.svg)](https://react.dev/)


### PR DESCRIPTION
Removes the red **Build, Test & Package** badge from the README while the GitHub Actions billing issue is unresolved. All other project badges remain unchanged.

Documentation-only change; no application code is affected.