### PR TITLE
Show installed version and support legacy IIS packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ $stagingPath = "C:\Temp\dbadash-webview-new"
 Expand-Archive -Path $releaseZip -DestinationPath $stagingPath -Force
 ```
 
-Release ZIPs produced by the current build workflow include `version.txt`. After deployment, this file identifies the installed release tag; CI artifacts built from a branch contain the source commit SHA instead. For an older deployment without `version.txt`, inspect `(Get-Item "C:\inetpub\dbadash\DBADashWebView.dll").VersionInfo.ProductVersion`; the value after `+` is the source commit SHA.
+Release ZIPs produced by the current build workflow include `version.txt`. After deployment, this file identifies the installed release tag; CI artifacts built from a branch contain the source commit SHA instead. Older deployments may not have this file; the About page and the verification command below automatically fall back to the assembly build information in that case.
 
 ### 2. Back up configuration and runtime state
 
@@ -426,7 +426,12 @@ The application needs modify permission on `config/` to save users, AD settings,
 ```powershell
 Start-WebAppPool -Name "DBADashWebView"
 Invoke-RestMethod "http://localhost:8080/api/health"
-Get-Content "$sitePath\version.txt"
+$installedVersion = if (Test-Path "$sitePath\version.txt") {
+    Get-Content "$sitePath\version.txt"
+} else {
+    (Get-Item "$sitePath\DBADashWebView.dll").VersionInfo.ProductVersion
+}
+$installedVersion
 ```
 
 Then verify that:
@@ -496,7 +501,7 @@ Configure via **Settings → Thresholds**. Define warning and critical levels pe
 
 ## 📡 API Reference
 
-All endpoints require JWT authentication via `Authorization: Bearer <token>` header.
+Protected endpoints require JWT authentication via an `Authorization: Bearer <token>` header. Health, version, and authentication bootstrap endpoints are public.
 
 <details>
 <summary><strong>Authentication</strong></summary>
@@ -505,6 +510,7 @@ All endpoints require JWT authentication via `Authorization: Bearer <token>` hea
 GET  /api/auth/status             Returns auth/bootstrap status
 POST /api/auth/login              { "username": "...", "password": "..." }  ->  { "token": "...", "role": "Admin|Operator|Viewer" }
 GET  /api/health                  Health check (no auth required)
+GET  /api/version                 Installed release or assembly build version (no auth required)
 ```
 </details>
 

--- a/backend.tests/ApplicationVersionProviderTests.cs
+++ b/backend.tests/ApplicationVersionProviderTests.cs
@@ -1,0 +1,70 @@
+using DBADashWebView;
+using Xunit;
+
+namespace DBADashWebView.Tests;
+
+public sealed class ApplicationVersionProviderTests
+{
+    [Fact]
+    public void Resolve_UsesTrimmedVersionMarker_WhenPresent()
+    {
+        var tempRoot = CreateTempDirectory();
+
+        try
+        {
+            File.WriteAllText(Path.Combine(tempRoot, "version.txt"), "  v0.2.6\r\n");
+
+            var result = ApplicationVersionProvider.Resolve(tempRoot, "1.0.0+fallback");
+
+            Assert.Equal("v0.2.6", result.Version);
+            Assert.Equal("version-file", result.Source);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_UsesAssemblyMetadata_WhenVersionMarkerIsMissing()
+    {
+        var tempRoot = CreateTempDirectory();
+
+        try
+        {
+            var result = ApplicationVersionProvider.Resolve(tempRoot, "1.0.0+abc123");
+
+            Assert.Equal("1.0.0+abc123", result.Version);
+            Assert.Equal("assembly", result.Source);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Resolve_UsesUnknown_WhenNoVersionInformationExists()
+    {
+        var tempRoot = CreateTempDirectory();
+
+        try
+        {
+            var result = ApplicationVersionProvider.Resolve(tempRoot, "  ");
+
+            Assert.Equal("unknown", result.Version);
+            Assert.Equal("assembly", result.Source);
+        }
+        finally
+        {
+            Directory.Delete(tempRoot, recursive: true);
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var path = Path.Combine(Path.GetTempPath(), "dbadashwebview-version-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/backend/ApplicationVersionProvider.cs
+++ b/backend/ApplicationVersionProvider.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+
+namespace DBADashWebView;
+
+public sealed record ApplicationVersionInfo(string Version, string Source);
+
+public sealed class ApplicationVersionProvider
+{
+    private const string VersionFileName = "version.txt";
+    private readonly string _contentRootPath;
+    private readonly string _assemblyVersion;
+
+    public ApplicationVersionProvider(IHostEnvironment environment)
+    {
+        _contentRootPath = environment.ContentRootPath;
+        _assemblyVersion = GetAssemblyVersion();
+    }
+
+    public ApplicationVersionInfo GetCurrentVersion() => Resolve(_contentRootPath, _assemblyVersion);
+
+    public static ApplicationVersionInfo Resolve(string contentRootPath, string assemblyVersion)
+    {
+        var versionPath = Path.Combine(contentRootPath, VersionFileName);
+
+        try
+        {
+            if (File.Exists(versionPath))
+            {
+                var releaseVersion = File.ReadAllText(versionPath).Trim();
+                if (!string.IsNullOrWhiteSpace(releaseVersion))
+                {
+                    return new ApplicationVersionInfo(releaseVersion, "version-file");
+                }
+            }
+        }
+        catch (IOException)
+        {
+            // Fall back to the assembly metadata when the marker can't be read.
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // Fall back to the assembly metadata when the marker can't be read.
+        }
+
+        var fallback = string.IsNullOrWhiteSpace(assemblyVersion) ? "unknown" : assemblyVersion.Trim();
+        return new ApplicationVersionInfo(fallback, "assembly");
+    }
+
+    private static string GetAssemblyVersion()
+    {
+        var assembly = typeof(ApplicationVersionProvider).Assembly;
+        return assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? assembly.GetName().Version?.ToString()
+            ?? "unknown";
+    }
+}

--- a/backend/Endpoints/AuthSettingsEndpointMappings.cs
+++ b/backend/Endpoints/AuthSettingsEndpointMappings.cs
@@ -9,6 +9,9 @@ public static class AuthSettingsEndpointMappings
     {
         endpoints.MapGet("/api/health", () => Results.Ok(new { status = "healthy", timestamp = DateTime.UtcNow }));
 
+        endpoints.MapGet("/api/version", (ApplicationVersionProvider versionProvider) =>
+            Results.Ok(versionProvider.GetCurrentVersion()));
+
         endpoints.MapGet("/api/auth/status", async (LocalUserStore localUsers, ActiveDirectoryAuthService adAuth, CancellationToken cancellationToken) =>
         {
             var localStatus = await localUsers.GetStatusAsync(cancellationToken);

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -1,3 +1,4 @@
+using DBADashWebView;
 using DBADashWebView.Auth;
 using DBADashWebView.Data;
 using DBADashWebView.Endpoints;
@@ -62,6 +63,7 @@ builder.Services.AddSingleton<LocalUserStore>();
 builder.Services.AddSingleton<ActiveDirectoryAuthService>();
 builder.Services.AddSingleton<ThresholdSettingsStore>();
 builder.Services.AddSingleton<SqlDataService>();
+builder.Services.AddSingleton<ApplicationVersionProvider>();
 
 var app = builder.Build();
 app.UseExceptionHandler("/api/error");

--- a/frontend/src/api/api.ts
+++ b/frontend/src/api/api.ts
@@ -2,6 +2,7 @@ import { clearAuthSession, getAuthSession, isAuthenticated, setAuthSession } fro
 import type {
   AdConfig,
   AdLoginTestResult,
+  ApplicationVersionResponse,
   AvailabilityGroupSummaryRow,
   BackupAmpelResponse,
   BackupManagementResponse,
@@ -124,6 +125,7 @@ export const api = {
     return response;
   },
   health: () => request<{ status: string }>('/api/health'),
+  version: () => request<ApplicationVersionResponse>('/api/version'),
   dashboardSummary: () => request<DashboardSummaryRow[]>('/api/dashboard/summary'),
   dashboardStats: () => request<DashboardStats>('/api/dashboard/stats'),
   instances: () => request<InstanceListRow[]>('/api/instances'),

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -10,6 +10,11 @@ export interface ApiErrorShape {
   message?: string;
 }
 
+export interface ApplicationVersionResponse {
+  version: string;
+  source: 'version-file' | 'assembly';
+}
+
 export interface AuthStatusResponse {
   localAuthEnabled: boolean;
   adEnabled: boolean;

--- a/frontend/src/pages/AboutPage.tsx
+++ b/frontend/src/pages/AboutPage.tsx
@@ -1,7 +1,29 @@
+import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
-import { ExternalLink, Github, Heart } from 'lucide-react';
+import { ExternalLink, Github, Heart, Tag } from 'lucide-react';
+import { api } from '../api/api';
+import type { ApplicationVersionResponse } from '../api/types';
 
 export default function AboutPage() {
+  const [versionInfo, setVersionInfo] = useState<ApplicationVersionResponse | null>(null);
+  const [versionUnavailable, setVersionUnavailable] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+
+    api.version()
+      .then((response) => {
+        if (active) setVersionInfo(response);
+      })
+      .catch(() => {
+        if (active) setVersionUnavailable(true);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
   return (
     <div className="max-w-3xl mx-auto space-y-6">
       <motion.h1 initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }} className="text-3xl font-bold text-white">
@@ -14,6 +36,18 @@ export default function AboutPage() {
           A modern web-based dashboard for SQL Server fleet monitoring, providing a browser-accessible read-only view
           of the data collected by <strong className="text-white">DBA Dash</strong>.
         </p>
+        <div className="flex flex-wrap items-center gap-3 rounded-lg border border-white/10 bg-white/5 px-4 py-3">
+          <Tag className="h-5 w-5 text-blue-400" />
+          <span className="text-sm text-gray-400">Installed version</span>
+          <code className="rounded bg-black/20 px-2 py-1 text-sm text-white">
+            {versionInfo?.version ?? (versionUnavailable ? 'Unavailable' : 'Loading…')}
+          </code>
+          {versionInfo && (
+            <span className="text-xs text-gray-500">
+              {versionInfo.source === 'version-file' ? 'Release package' : 'Assembly fallback (legacy package)'}
+            </span>
+          )}
+        </div>
       </motion.div>
 
       <motion.div initial={{ opacity: 0, y: 10 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }}

--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -111,3 +111,26 @@ test('redirects viewers away from admin settings routes', async ({ page }) => {
   await expect(page).toHaveURL(/\/$/);
   await expect(page.getByRole('heading', { name: 'Summary' })).toBeVisible();
 });
+
+test('shows the installed application version on the About page', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('auth-session', JSON.stringify({
+      token: 'admin-jwt',
+      username: 'admin',
+      displayName: 'Administrator',
+      role: 'Admin',
+      source: 'local',
+    }));
+  });
+
+  await mockShellApis(page);
+  await page.route('**/api/version', async (route) => {
+    await route.fulfill({ json: { version: 'v0.2.6', source: 'version-file' } });
+  });
+
+  await page.goto('/about');
+
+  await expect(page.getByRole('heading', { name: 'About DBA Dash WebView' })).toBeVisible();
+  await expect(page.getByText('v0.2.6', { exact: true })).toBeVisible();
+  await expect(page.getByText('Release package', { exact: true })).toBeVisible();
+});


### PR DESCRIPTION
Closes #97.

## Changes
- add a public `/api/version` endpoint
- show the installed version on the About page
- prefer `version.txt` for current release packages
- fall back to assembly build metadata for older installations without `version.txt`
- make the IIS verification command safe for both package formats
- document the new endpoint and add regression coverage

## Verification
- 35 backend tests passed
- 12 frontend tests passed
- 3 Playwright end-to-end tests passed
- targeted ESLint check passed
- frontend production build passed
- backend Release build passed