### PR TITLE
Ignore local publish output and release archive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ Thumbs.db
 
 # Local release packages
 artifacts/
+publish/
+backend/publish/
+dbadash-webview.zip


### PR DESCRIPTION
## Description

`dotnet publish` and the release packaging step write `publish/`,
`backend/publish/` and `dbadash-webview.zip` into the working tree. None of
them were ignored, so a local release build left the repository dirty — and
made it easy to stage several thousand build artefacts by accident.

The paths come straight from `.github/workflows/build.yml`:

- `dotnet publish -c Release -o ../publish` → `publish/`
- `Compress-Archive -Path publish\* -DestinationPath dbadash-webview.zip` → `dbadash-webview.zip`
- `backend/publish/` is the same output when `dotnet publish` is run from the
  repository root instead of `backend/`

`.gitignore` already covered `artifacts/`, so these three are added to the same
"Local release packages" section. Verified that no currently tracked file is
hidden by the new patterns.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] Other: repository hygiene / build configuration

## Checklist

- [x] `npm run build` passes (frontend)
- [x] `dotnet build` passes (backend)
- [x] Tested in browser (dark theme) — n/a, no runtime or UI change
- [x] No new TypeScript errors — n/a, no TypeScript touched (`tsc -b` still clean)
- [x] SQL queries use parameterized `@param` (no string concat) — n/a, no SQL in this change

## Screenshots

n/a — `.gitignore` only, no user-visible change.