### PR TITLE
Fix RBAC tag scope querying non-existent tag tables

### DIFF
--- a/backend.tests/UserScopeTests.cs
+++ b/backend.tests/UserScopeTests.cs
@@ -87,8 +87,8 @@ public sealed class UserScopeTests
         Assert.Contains("i.InstanceID IN", predicate);
         Assert.Contains("@scope_tag_0", predicate);
         Assert.Contains("@scope_tag_1", predicate);
-        Assert.Contains("dbo.InstanceTag", predicate);
-        Assert.Contains("dbo.Tag", predicate);
+        Assert.Contains("dbo.InstanceIDsTags", predicate);
+        Assert.Contains("dbo.Tags", predicate);
         // Values must not be inlined into the SQL.
         Assert.DoesNotContain("prod", predicate);
         Assert.DoesNotContain("eu-west", predicate);

--- a/backend/Auth/UserScope.cs
+++ b/backend/Auth/UserScope.cs
@@ -72,7 +72,7 @@ public sealed class UserScope
     /// caller must pass the resulting parameters from
     /// <see cref="AppendParameters"/> to the command.
     ///
-    /// The predicate joins against <c>dbo.InstanceTag</c> / <c>dbo.Tag</c>
+    /// The predicate joins against <c>dbo.InstanceIDsTags</c> / <c>dbo.Tags</c>
     /// (standard DBA Dash tag schema) for tag scope. Group scope is not yet
     /// enforced at the SQL layer — the values are kept on the JWT so admins
     /// can opt-in once the consuming deployment standardises on a group
@@ -91,7 +91,7 @@ public sealed class UserScope
             .ToArray();
 
         var inList = string.Join(", ", paramNames);
-        return $"{instanceIdColumn} IN (SELECT it.InstanceID FROM dbo.InstanceTag it JOIN dbo.Tag t ON it.TagID = t.TagID WHERE t.TagName IN ({inList}))";
+        return $"{instanceIdColumn} IN (SELECT it.InstanceID FROM dbo.InstanceIDsTags it JOIN dbo.Tags t ON it.TagID = t.TagID WHERE t.TagName IN ({inList}))";
     }
 
     /// <summary>
@@ -151,7 +151,7 @@ public sealed class UserScope
         }
 
         var paramNames = string.Join(", ", AllowedTags.Select((_, index) => "@scope_tag_" + index));
-        var query = $"SELECT DISTINCT it.InstanceID FROM dbo.InstanceTag it JOIN dbo.Tag t ON it.TagID = t.TagID WHERE t.TagName IN ({paramNames})";
+        var query = $"SELECT DISTINCT it.InstanceID FROM dbo.InstanceIDsTags it JOIN dbo.Tags t ON it.TagID = t.TagID WHERE t.TagName IN ({paramNames})";
 
         var rows = await sql.QueryAsync(query, cancellationToken, ParameterTuples().ToArray());
         var ids = new HashSet<int>();
@@ -184,7 +184,7 @@ public sealed class UserScope
         parameters.AddRange(ParameterTuples());
 
         var paramNames = string.Join(", ", AllowedTags.Select((_, index) => "@scope_tag_" + index));
-        var query = $"SELECT TOP 1 1 FROM dbo.InstanceTag it JOIN dbo.Tag t ON it.TagID = t.TagID WHERE it.InstanceID = @instanceId AND t.TagName IN ({paramNames})";
+        var query = $"SELECT TOP 1 1 FROM dbo.InstanceIDsTags it JOIN dbo.Tags t ON it.TagID = t.TagID WHERE it.InstanceID = @instanceId AND t.TagName IN ({paramNames})";
 
         var rows = await sql.QueryAsync(query, cancellationToken, parameters.ToArray());
         return rows.Count > 0;


### PR DESCRIPTION
## Description

`UserScope` built its tag-scope predicates against `dbo.InstanceTag` and `dbo.Tag`.
Neither table exists in a DBA Dash repository — the real names are
`dbo.InstanceIDsTags` and `dbo.Tags`. Every scoped query therefore failed with
`Invalid object name`, so any user with a tag scope claim got an error instead of
a filtered result, on all three code paths:

- `BuildInstanceFilter` — the inline predicate spliced into list/aggregate queries
- `AllowedInstanceIdsAsync` — the allowed-id set used for post-query filtering
- `IsInstanceAllowedAsync` — the per-instance access check

Running main's exact predicate against a real DBA Dash repository (SQL Server 2022):

The same query with the corrected names returns rows normally.

The existing test asserted the incorrect names, so it pinned the bug rather than
catching it — which is why this survived. It now asserts the real schema.

### Verification

Beyond the unit tests, this was checked end-to-end against a populated DBA Dash
repository with a `Viewer` restricted by tag:

- before: every scoped page failed with `Invalid object name 'dbo.InstanceTag'`
- after: the user sees a correctly filtered dashboard, drives and query list
- a `Viewer` whose tag matches no instance sees **zero** rows — it fails closed,
  not open

### Note

`#100`'s tag picker depends on this predicate, so this unblocks it independently
of the larger tag work in `#104`.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [ ] Other: ___

## Checklist

- [x] `npm run build` passes (frontend)
- [x] `dotnet build` passes (backend)
- [x] Tested in browser (dark theme)
- [x] No new TypeScript errors — n/a, no frontend files touched
- [x] SQL queries use parameterized `@param` (no string concat)

## Screenshots

n/a — no visual change. The user-visible effect is that tag-scoped users get data
instead of an error.